### PR TITLE
Added troubleshooting section to documentation

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,16 +5,16 @@ Here are some tips to overcome issues you may run into while using
 DevShop.
 
 
-`queued tasks are not completing`
----------------------------------
+queued tasks are not completing
+-------------------------------
 
 If tasks are being queued up, but not running you may have to restart
 your queue runner. To do so run the following from the command line on
 your web server:
 
 ```
-sudo supervisor stop
-sudo supervisor start
+sudo service supervisor stop
+sudo service supervisor start
 ```
 
 Your queued tasks should start running again.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,20 @@
+Troubleshooting
+=================
+
+Here are some tips to overcome issues you may run into while using
+DevShop.
+
+
+`queued tasks are not completing`
+---------------------------------
+
+If tasks are being queued up, but not running you may have to restart
+your queue runner. To do so run the following from the command line on
+your web server:
+
+```
+sudo supervisor stop
+sudo supervisor start
+```
+
+Your queued tasks should start running again.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,4 +22,5 @@ pages:
   - 'Remote Servers': 'remotes.md'
   - 'Going Live': 'going-live.md'
   - 'Scaling': 'scaling.md'
+  - 'Troubleshooting': 'troubleshooting.md'
 


### PR DESCRIPTION
I added a troubleshooting section to the Management section in the nav, including how to restart the queue runner.  Let me know if you feel troubleshooting should live elsewhere.

Also let me know if the formatting and the language is clear.  Thanks for the review!