### PR TITLE
Fix typo in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ Setup
 - Login to your server as root, and retrieve and run the install script:
 
         root@devshop:~# wget https://raw.githubusercontent.com/opendevshop/devshop/0.3.0/install.sh
-        root@devshop:~# bash install
+        root@devshop:~# bash install.sh
 
 Chasing Head
 ------------


### PR DESCRIPTION
Just small typo...
```
root@ds:~# bash install
/usr/bin/install: /usr/bin/install: cannot execute binary file
root@ds:~# bash install.sh 
=============================================
 Welcome to the DevShop Standalone Installer 
```