### PR TITLE
Move git install outside of ansible install.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,6 @@ if [ ! `which ansible` ]; then
         fi
 
         apt-get update -qq
-        apt-get install git -y -qq
         apt-get install $PACKAGE -y -qq
         apt-add-repository ppa:ansible/ansible -y
         apt-get update -qq
@@ -173,7 +172,6 @@ if [ ! `which ansible` ]; then
 
     elif [ $OS == 'centos' ] || [ $OS == 'redhat' ] || [ $OS == 'fedora'  ]; then
 
-        yum install git -y
         yum install epel-release -y
         yum install ansible -y
     fi
@@ -185,6 +183,14 @@ else
     echo $LINE
 fi
 
+# Install git.
+if [ $OS == 'ubuntu' ] || [ $OS == 'debian' ]; then
+  apt-get install git -y -qq
+        
+elif [ $OS == 'centos' ] || [ $OS == 'redhat' ] || [ $OS == 'fedora'  ]; then
+    yum install epel-release -y
+    yum install git -y
+fi
 
 # Generate MySQL Password
 if [ "$TRAVIS" == "true" ]; then


### PR DESCRIPTION
If ansible is already installed, it will skip the installation of git, causing a failure down the road.

This breaks git out into it's own if statement.