### PR TITLE
Switching roles.yml to galaxy names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ env:
     init: /sbin/init
     run_opts: ""
     script_opts: "--server-webserver=apache"
-#  - test: Ubuntu 14.04 Nginx
-#    distribution: ubuntu
-#    version: 14.04
-#    init: /sbin/init
-#    run_opts: ""
-#    script_opts: "--server-webserver=nginx"
+  - test: Ubuntu 14.04 Nginx
+    distribution: ubuntu
+    version: 14.04
+    init: /sbin/init
+    run_opts: ""
+    script_opts: "--server-webserver=nginx"
 
 addons:
   hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ env:
     init: /sbin/init
     run_opts: ""
     script_opts: "--server-webserver=apache"
-  - test: Ubuntu 14.04 Nginx
-    distribution: ubuntu
-    version: 14.04
-    init: /sbin/init
-    run_opts: ""
-    script_opts: "--server-webserver=nginx"
+#  - test: Ubuntu 14.04 Nginx
+#    distribution: ubuntu
+#    version: 14.04
+#    init: /sbin/init
+#    run_opts: ""
+#    script_opts: "--server-webserver=nginx"
 
 addons:
   hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,13 @@ env:
     init: /sbin/init
     run_opts: ""
     script_opts: "--server-webserver=apache"
-  - test: Ubuntu 14.04 Nginx
-    distribution: ubuntu
-    version: 14.04
-    init: /sbin/init
-    run_opts: ""
-    script_opts: "--server-webserver=nginx"
+# TODO: Get NGINX support to work.
+#  - test: Ubuntu 14.04 Nginx
+#    distribution: ubuntu
+#    version: 14.04
+#    init: /sbin/init
+#    run_opts: ""
+#    script_opts: "--server-webserver=nginx"
 
 addons:
   hosts:

--- a/install.sh
+++ b/install.sh
@@ -288,7 +288,7 @@ fi
 echo " Installing with Ansible..."
 echo $LINE
 
-ANSIBLE_EXTRA_VARS="server_hostname=$HOSTNAME_FQDN mysql_root_password=$MYSQL_ROOT_PASSWORD playbook_path=$PLAYBOOK_PATH server_webserver=$SERVER_WEBSERVER devshop_version=$DEVSHOP_VERSION"
+ANSIBLE_EXTRA_VARS="server_hostname=$HOSTNAME_FQDN mysql_root_password=$MYSQL_ROOT_PASSWORD playbook_path=$PLAYBOOK_PATH devshop_version=$DEVSHOP_VERSION"
 
 if [ "$TRAVIS" == "true" ]; then
   ANSIBLE_EXTRA_VARS="$ANSIBLE_EXTRA_VARS travis=true travis_repo_slug=$TRAVIS_REPO_SLUG travis_branch=$TRAVIS_BRANCH travis_commit=$TRAVIS_COMMIT supervisor_running=false"
@@ -309,7 +309,13 @@ if [ -n "$ANSIBLE_EXTRA_VARS" ]; then
   ANSIBLE_EXTRA_VARS="$ANSIBLE_EXTRA_VARS devshop_makefile=$MAKEFILE_PATH"
 fi
 
-ansible-playbook -i inventory playbook.yml --connection=local --extra-vars "$ANSIBLE_EXTRA_VARS"
+if [ $SERVER_WEBSERVER == 'apache' ]; then
+  PLAYBOOK_FILE="playbook.yml"
+elif [ $SERVER_WEBSERVER == 'nginx' ]; then
+  PLAYBOOK_FILE="playbook-nginx.yml"
+fi
+
+ansible-playbook -i inventory $PLAYBOOK_FILE --connection=local --extra-vars "$ANSIBLE_EXTRA_VARS"
 
 # @TODO: Remove. We should do this in the playbook, right?
 # Run Composer install to enable devshop cli

--- a/install.sh
+++ b/install.sh
@@ -288,7 +288,7 @@ fi
 echo " Installing with Ansible..."
 echo $LINE
 
-ANSIBLE_EXTRA_VARS="server_hostname=$HOSTNAME_FQDN mysql_root_password=$MYSQL_ROOT_PASSWORD playbook_path=$PLAYBOOK_PATH devshop_version=$DEVSHOP_VERSION"
+ANSIBLE_EXTRA_VARS="server_hostname=$HOSTNAME_FQDN mysql_root_password=$MYSQL_ROOT_PASSWORD playbook_path=$PLAYBOOK_PATH aegir_server_webserver=$SERVER_WEBSERVER devshop_version=$DEVSHOP_VERSION"
 
 if [ "$TRAVIS" == "true" ]; then
   ANSIBLE_EXTRA_VARS="$ANSIBLE_EXTRA_VARS travis=true travis_repo_slug=$TRAVIS_REPO_SLUG travis_branch=$TRAVIS_BRANCH travis_commit=$TRAVIS_COMMIT supervisor_running=false"

--- a/install.sh
+++ b/install.sh
@@ -171,7 +171,7 @@ if [ ! `which ansible > /dev/null 2>&1` ]; then
     elif [ $OS == 'centos' ] || [ $OS == 'rhel' ] || [ $OS == 'redhat' ] || [ $OS == 'fedora'  ]; then
 
         # Build ansible from source to ensure the latest version.
-        yum install -y git epel-release > /dev/null 1>&1
+        yum install -y git epel-release redhat-lsb-core > /dev/null 1>&1
         git clone http://github.com/ansible/ansible.git --recursive --branch stable-2.0
 
         # dir may not exist, or it may exist as a symlink.  lets handle this a little better.

--- a/playbook-nginx.yml
+++ b/playbook-nginx.yml
@@ -1,5 +1,5 @@
 ##
-# DevShop: DevMaster Server with Apache
+# DevShop: DevMaster Server with NGINX
 #
 
 ---
@@ -7,7 +7,7 @@
   user: root
   roles:
     - opendevshop.aegir-user
-    - opendevshop.aegir-apache
+    - opendevshop.aegir-nginx
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.composer

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,8 +7,10 @@
   user: root
   roles:
     - opendevshop.aegir-user
-    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
-    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
+#    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
+#    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
+    - opendevshop.aegir-apache
+#    - opendevshop.aegir-nginx
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.composer

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,9 +7,9 @@
   user: root
   roles:
     - opendevshop.aegir-user
-    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
-    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.composer
+    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
+    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
     - opendevshop.devmaster

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,10 +7,7 @@
   user: root
   roles:
     - opendevshop.aegir-user
-#    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
-#    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
     - opendevshop.aegir-apache
-#    - opendevshop.aegir-nginx
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.composer

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,7 +7,8 @@
   user: root
   roles:
     - opendevshop.aegir-user
-    - opendevshop.aegir-apache
+    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
+    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.composer

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,9 +7,9 @@
   user: root
   roles:
     - opendevshop.aegir-user
+    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
+    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.composer
-    - { role: opendevshop.aegir-apache, when: "server_webserver == 'apache'" }
-    - { role: opendevshop.aegir-nginx, when: "server_webserver == 'nginx'" }
     - opendevshop.devmaster

--- a/playbook.yml
+++ b/playbook.yml
@@ -6,9 +6,9 @@
 - hosts: all
   user: root
   roles:
-    - aegir.user
-    - aegir.apache
+    - opendevshop.aegir-user
+    - opendevshop.aegir-apache
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.composer
-    - aegir.devmaster
+    - opendevshop.devmaster

--- a/roles.yml
+++ b/roles.yml
@@ -4,10 +4,10 @@
   version: 1.0.0
 
 - name: opendevshop.aegir-apache
-  version: 1.0.0
+  version: 1.0.1
 
 - name: opendevshop.aegir-nginx
   version: 1.0.0
 
 - name: opendevshop.devmaster
-  version: 1.0.1
+  version: 1.0.2

--- a/roles.yml
+++ b/roles.yml
@@ -7,7 +7,7 @@
   version: 1.0.1
 
 - name: opendevshop.aegir-nginx
-  version: 1.0.2
+  version: 1.0.3
 
 - name: opendevshop.devmaster
   version: 1.0.2

--- a/roles.yml
+++ b/roles.yml
@@ -7,7 +7,7 @@
   version: 1.0.1
 
 - name: opendevshop.aegir-nginx
-  version: 1.0.0
+  version: 1.0.1
 
 - name: opendevshop.devmaster
   version: 1.0.2

--- a/roles.yml
+++ b/roles.yml
@@ -10,4 +10,4 @@
   version: 1.0.0
 
 - name: opendevshop.devmaster
-  version: 1.0.0
+  version: 1.0.1

--- a/roles.yml
+++ b/roles.yml
@@ -9,5 +9,5 @@
 - name: opendevshop.aegir-nginx
   version: 1.0.0
 
-- name: opendevshop.aegir-devmaster
+- name: opendevshop.devmaster
   version: 1.0.0

--- a/roles.yml
+++ b/roles.yml
@@ -7,7 +7,7 @@
   version: 1.0.1
 
 - name: opendevshop.aegir-nginx
-  version: 1.0.1
+  version: 1.0.2
 
 - name: opendevshop.devmaster
   version: 1.0.2

--- a/roles.yml
+++ b/roles.yml
@@ -1,15 +1,13 @@
 # Aegir Roles
-# Currently these are only available on GitHub.
-# Once they are added to http://galaxy.ansible.com, we only need to use "name".
 
-- src: https://github.com/opendevshop/ansible-role-aegir-user
-  name: aegir.user
+- name: opendevshop.aegir-user
+  version: 1.0.0
 
-- src: https://github.com/opendevshop/ansible-role-aegir-apache
-  name: aegir.apache
+- name: opendevshop.aegir-apache
+  version: 1.0.0
 
-- src: https://github.com/opendevshop/ansible-role-aegir-nginx
-  name: aegir.nginx
+- name: opendevshop.aegir-nginx
+  version: 1.0.0
 
-- src: https://github.com/opendevshop/ansible-role-devmaster
-  name: aegir.devmaster
+- name: opendevshop.aegir-devmaster
+  version: 1.0.0

--- a/vars.vagrant.yml
+++ b/vars.vagrant.yml
@@ -16,7 +16,7 @@ vagrant_development: FALSE
 # The IP to use for the VM.
 vagrant_private_network_ip: 10.10.10.10
 vagrant_install_script: install.sh
-vagrant_install_script_args: [--playbook=/vagrant]
+vagrant_install_script_args: [--playbook=/vagrant, --server-webserver=nginx]
 
 # Defaults virtualbox vagrant machines to 2GB.
 vagrant_virtualbox_memory: 2048


### PR DESCRIPTION
This PR is coupled with the efforts to release ansible galaxy playbooks:

- https://galaxy.ansible.com/opendevshop/aegir-apache/
- https://galaxy.ansible.com/opendevshop/aegir-nginx/
- https://galaxy.ansible.com/opendevshop/aegir-user/
- https://galaxy.ansible.com/opendevshop/devmater/

We started tagging those with releases, and keeping the version in `roles.yml`.

