### PR TITLE
Check for the ansible executable, not the folder.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,8 @@ if [ $SERVER_WEBSERVER != 'nginx' ] && [ $SERVER_WEBSERVER != 'apache' ]; then
 fi
 
 # If ansible command is not available, install it.
-if [ ! -f "/usr/bin/ansible" ]; then
+# Decided on "hash" thanks to http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script
+if [ ! `hash ansible 2>/dev/null` ]; then
     echo " Installing Ansible..."
 
     if [ $OS == 'ubuntu' ] || [ $OS == 'debian' ]; then

--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,7 @@ if [ $SERVER_WEBSERVER != 'nginx' ] && [ $SERVER_WEBSERVER != 'apache' ]; then
 fi
 
 # If ansible command is not available, install it.
-if [ ! -d "/etc/ansible" ]; then
+if [ ! -f "/usr/bin/ansible" ]; then
     echo " Installing Ansible..."
 
     if [ $OS == 'ubuntu' ] || [ $OS == 'debian' ]; then


### PR DESCRIPTION
Our docker images for testing create /etc/ansible/hosts.

That's why the install.sh is failing.

Let's just test for /usr/bin/ansible?

Is this crazy? Seems like this is the place ansible will always be installed. Unless someone is setting up ansible manually and wanted it in a different folder... 

Seems like the worst case would be the install.sh will try to install ansible again and safely fail thanks to apt/yum.