### PR TITLE
Cleanup the tests now that hosting-tasks can be un un-forked.

### DIFF
--- a/src/DevShop/Command/Upgrade.php
+++ b/src/DevShop/Command/Upgrade.php
@@ -3,23 +3,14 @@
 namespace DevShop\Command;
 
 use DevShop\Console\Command;
-
-use Github\Exception\RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
-
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Process\Process;
-use Github\Client;
-
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
-use Symfony\Component\Finder\Finder;
 
 class Upgrade extends Command
 {
@@ -33,6 +24,13 @@ class Upgrade extends Command
         InputArgument::OPTIONAL,
         'The git tag or branch to install.'
       )
+
+      // makefile
+      ->addOption(
+        'makefile', NULL, InputOption::VALUE_OPTIONAL,
+        'The makefile to use to build the devmaster platform.'
+      )
+
     ;
   }
 
@@ -113,13 +111,17 @@ class Upgrade extends Command
     while ($this->checkVersion($target_version) == FALSE) {
       $question = new Question("Target Version: (Default: $default_version) ", $default_version);
       $target_version = $helper->ask($input, $output, $question);
-      $devmaster_makefile = "https://raw.githubusercontent.com/opendevshop/devshop/$target_version/build-devmaster.make";
 
       if (!$this->checkVersion($target_version)) {
         $output->writeln("<fg=red>Version $target_version not found</>");
       }
     }
     $output->writeln("Version $target_version confirmed.");
+
+    $devmaster_makefile = $input->getOption('makefile');
+    if (empty($devmaster_makefile)) {
+      $devmaster_makefile = "https://raw.githubusercontent.com/opendevshop/devshop/$target_version/build-devmaster.make";
+    }
 
 
     // Determine the target path.

--- a/tests/features/project.create.feature
+++ b/tests/features/project.create.feature
@@ -99,6 +99,7 @@ Feature: Create a project
     And I fill in "test" for "Environment Name"
     And I select "master" from "Branch or Tag"
     And I select the radio button "Drupal Profile"
+    Then I select the radio button "Standard Install with commonly used features pre-configured."
 
     #@TODO: Check lots of settings
 

--- a/tests/features/project.create.feature
+++ b/tests/features/project.create.feature
@@ -120,8 +120,4 @@ Feature: Create a project
     And I should see "Environment Settings"
 
     When I click "http://test.drpl8.devshop.travis"
-
-    # @TODO: Fix the problem preventing this site from loading.
-    # We don't have time to spend on this obscure edge case bug before the next release.
-    Then print last response
-#    And I should see "Welcome to test.drpl8.devshop.travis"
+    Then I should see "test.drpl8.devshop.travis" in the ".site-branding__name" element

--- a/tests/features/project.create.feature
+++ b/tests/features/project.create.feature
@@ -30,7 +30,7 @@ Feature: Create a project
 
     When I run drush "hosting-tasks --fork=0 --strict=0"
     Then print last drush output
-    And I wait "10" seconds
+#    And I wait "10" seconds
     And I reload the page
     And I reload the page
 
@@ -54,7 +54,7 @@ Feature: Create a project
 
     When I run drush "hosting-tasks --fork=0 --strict=0"
     Then print last drush output
-    And I wait "10" seconds
+#    And I wait "10" seconds
     And I reload the page
 
     Then I should see "dev"
@@ -62,7 +62,7 @@ Feature: Create a project
     And I should see "master"
 
     And I should see "master"
-    And I wait "10" seconds
+#    And I wait "10" seconds
     And I reload the page
 #    When I click "Process Failed"
 #    Then print last response
@@ -85,7 +85,7 @@ Feature: Create a project
     Then print last drush output
     Then drush output should not contain "This task is already running, use --force"
 
-    Then I wait "5" seconds
+#    Then I wait "5" seconds
     And I reload the page
     Then I should see the link "dev"
     Then I should see the link "live"
@@ -112,7 +112,7 @@ Feature: Create a project
     When I run drush "hosting-tasks --fork=0 --strict=0"
     Then print last drush output
 
-    And I wait "10" seconds
+#    And I wait "10" seconds
 
     When I click "test"
     Then I should see "Environment Dashboard"

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -10,6 +10,7 @@ fi
 
 # Get argument as the version we should install.
 UPGRADE_FROM_VERSION=$1
+UPGRADE_TO_MAKEFILE=$2
 
 echo ">env"
 env
@@ -39,7 +40,7 @@ sudo bash install.sh --makefile=https://raw.githubusercontent.com/opendevshop/de
 
 echo "Running devshop:upgrade command..."
 devshop self-update
-devshop upgrade $UPGRADE_TO_VERSION -n
+devshop upgrade $UPGRADE_TO_VERSION -n --makefile=$UPGRADE_TO_MAKEFILE
 
 su - aegir -c "drush @hostmaster hosting-tasks"
 

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -15,11 +15,24 @@ UPGRADE_TO_MAKEFILE=$2
 echo ">env"
 env
 
-# Detect version to install from Travis variables.
-if [ -z $TRAVIS_PULL_REQUEST_BRANCH ]; then
-  UPGRADE_TO_VERSION=$TRAVIS_BRANCH
-else
-  UPGRADE_TO_VERSION=$TRAVIS_PULL_REQUEST_BRANCH
+# If repo being tested is devshop... use the build branch as the upgrade target.
+if [ "$TRAVIS_REPO_SLUG"=="opendevshop/devshop" ]; then
+
+    # If TRAVIS_PULL_REQUEST_BRANCH variable doesn't exist, it's not a pull request, use the $TRAV)S_BRANCH variable.
+    if [ -z $TRAVIS_PULL_REQUEST_BRANCH ]; then
+      UPGRADE_TO_VERSION=$TRAVIS_BRANCH
+    else
+      UPGRADE_TO_VERSION=$TRAVIS_PULL_REQUEST_BRANCH
+    fi
+
+elif [ "$TRAVIS_REPO_SLUG"=="opendevshop/devmaster" ]; then
+
+    # If DEVSHOP_UPGRADE_TO_VERSION variable is not set, use 1.x.
+    if [ -z $DEVSHOP_UPGRADE_TO_VERSION ]; then
+      UPGRADE_TO_VERSION="1.x"
+    else
+      UPGRADE_TO_VERSION=$DEVSHOP_UPGRADE_TO_VERSION
+    fi
 fi
 
 if [ -z $UPGRADE_FROM_VERSION ]; then

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -52,7 +52,7 @@ curl -OL "https://github.com/opendevshop/devshop/releases/download/$UPGRADE_FROM
 sudo bash install.sh --makefile=https://raw.githubusercontent.com/opendevshop/devshop/$UPGRADE_FROM_VERSION/build-devmaster.make
 
 echo "Running devshop:upgrade command..."
-devshop self-update
+devshop self-update $UPGRADE_TO_VERSION
 devshop upgrade $UPGRADE_TO_VERSION -n --makefile=$UPGRADE_TO_MAKEFILE
 
 su - aegir -c "drush @hostmaster hosting-tasks"


### PR DESCRIPTION
We had to add many "wait X seconds" steps to get tests to work because the `drush hosting-tasks` command runs commands in a forked process.

We patched Aegir Hosting in https://www.drupal.org/node/2828630#comment-11852454 allowing to block forking, making test runs better: we get output and we block further testing until the tasks are complete.