### PR TITLE
Add "behat-path" option to the devmaster:test command.

### DIFF
--- a/src/DevShop/Command/DevmasterTest.php
+++ b/src/DevShop/Command/DevmasterTest.php
@@ -72,8 +72,15 @@ class DevmasterTest extends Command {
     
     // Check behat path.
     if (empty($input->getOption('behat-path'))) {
-      // If no behat path is set, use this repository root / tests.
-      $input->setOption('behat-path', __DIR__ . '/../../../tests');
+      
+      // Use environment variable if one exists.
+      if (!empty($_SERVER['BEHAT_PATH'])) {
+        $input->setOption('behat-path', $_SERVER['BEHAT_PATH']);
+      }
+      else {
+        // If no behat path is set, use this repository root / tests.
+        $input->setOption('behat-path', __DIR__ . '/../../../tests');
+      }
     }
     
     // Check that the behat path is valid.

--- a/src/DevShop/Command/DevmasterTest.php
+++ b/src/DevShop/Command/DevmasterTest.php
@@ -46,6 +46,12 @@ class DevmasterTest extends Command {
         InputOption::VALUE_OPTIONAL,
         'A test name to pass to bin/behat --name option'
       )
+      ->addOption(
+        'behat-path',
+        '',
+        InputOption::VALUE_OPTIONAL,
+        'The absolute path to the tests to run. Defaults to DevShop CLI path.'
+      )
     ;
   }
 
@@ -62,6 +68,17 @@ class DevmasterTest extends Command {
     else {
       $output->writeln("<error>Hostmaster alias not found.</error>");
       exit(1);
+    }
+    
+    // Check behat path.
+    if (empty($input->getOption('behat-path'))) {
+      // If no behat path is set, use this repository root / tests.
+      $input->setOption('behat-path', __DIR__ . '/../../../tests');
+    }
+    
+    // Check that the behat path is valid.
+    if (!file_exists($input->getOption('behat-path') . '/behat.yml')) {
+      throw new \Exception('No behat.yml found at ' . $input->getOption('behat-path'));
     }
   }
 
@@ -106,7 +123,7 @@ class DevmasterTest extends Command {
     
     $process = new Process($cmd);
     $process->setTimeout(NULL);
-    $process->setWorkingDirectory(__DIR__ . '/../../../tests');
+    $process->setWorkingDirectory($input->getOption('behat-path'));
     $process->setEnv(array(
       'HOME' => '/var/aegir',
       'PATH' => getenv('PATH') . ':/usr/share/composer/vendor/bin/',

--- a/src/DevShop/Command/DevmasterTest.php
+++ b/src/DevShop/Command/DevmasterTest.php
@@ -87,6 +87,9 @@ class DevmasterTest extends Command {
     if (!file_exists($input->getOption('behat-path') . '/behat.yml')) {
       throw new \Exception('No behat.yml found at ' . $input->getOption('behat-path'));
     }
+    else {
+      $output->writeln("Running Behat tests located at " . $input->getOption('behat-path'));
+    }
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {


### PR DESCRIPTION
I am going to move the tests to the devmaster repo so first, let's make the behat path option configurable.

- Add an option to `devshop devmaster:test` command: `devshop devmaster:test --behat-path=/path/to/behat/files`
- Allow the use of an Environment variable instead of an option, which allows us to set path to behat in Docker environment variables.