### PR TITLE
README.md typo in tour link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [aegir.coop](http://aegir.coop) for more information.
 
 # Tour
 
-See the [Tour](http://docs.opendevshop.com/tour.htmld) section of the documentation for a quick walkthrough of the DevShop interface.
+See the [Tour](http://docs.opendevshop.com/tour.html) section of the documentation for a quick walkthrough of the DevShop interface.
 
 # Support
 


### PR DESCRIPTION
Fixed a small typo in the tour link (.htmld instead of .html)