### PR TITLE
Implement new Hosting Git hooks instead of using devmaster code.

### DIFF
--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -13,10 +13,8 @@ projects:
     type: profile
     download:
       type: git
+      branch: hosting-git-hooks      # Development branch. Delete before merge.
       branch: 1.x
-
-      # Development branch. Delete before merge.
-      branch: hosting-git-hooks
       url: http://github.com/opendevshop/devmaster.git
 
   devel:
@@ -30,10 +28,8 @@ projects:
   hosting_git:
     download:
       type: git
+      branch: 2897894-git-hooks   # Development branch. Delete before merge.
       branch: 7.x-3.x
-
-      # Development branch. Delete before merge.
-      branch: 2897894-git-hooks
 
   hosting_remote_import:
     download:

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -14,6 +14,9 @@ projects:
     download:
       type: git
       branch: 1.x
+
+      # Development branch. Delete before merge.
+      branch: hosting-git-hooks
       url: http://github.com/opendevshop/devmaster.git
 
   devel:
@@ -28,6 +31,9 @@ projects:
     download:
       type: git
       branch: 7.x-3.x
+
+      # Development branch. Delete before merge.
+      branch: 2897894-git-hooks
 
   hosting_remote_import:
     download:


### PR DESCRIPTION
Forever, we've used "deployment hooks" as a way to keep track of what things should be run when code changes (git pull, etc.).

Hosting Git module is finally getting this feature natively (also written by me).

This PR starts the process of removing our own deployment hooks and using Hosting Git module instead.

See https://www.drupal.org/project/hosting_git/issues/2897894