### PR TITLE
Ubuntu 16

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,15 +3,15 @@
 #  DevShop Standalone Install Script
 #  =================================
 #
-#  This script will install a full devshop server from scratch. 
-#  
+#  This script will install a full devshop server from scratch.
+#
 #  Please read the full "Installing DevShop" instructions at https://devshop.readthedocs.org/en/latest/install/
 #
 #  Before you start, please visit https://github.com/opendevshop/devshop/releases to be sure you have the latest version of this script,
 #  Or you may try the 0.x script with the URL https://raw.githubusercontent.com/opendevshop/devshop/0.x/install.sh
-# 
+#
 #  Must run with root or sudo privileges:
-#  
+#
 #    ubuntu@devshop:~$ wget https://raw.githubusercontent.com/opendevshop/devshop/0.x/install.sh
 #    ubuntu@devshop:~$ bash install.sh
 #
@@ -23,7 +23,7 @@
 
 # Version used for cloning devshop playbooks
 # Must be a branch or tag.
-DEVSHOP_VERSION=1.x
+DEVSHOP_VERSION=ubuntu-16
 SERVER_WEBSERVER=apache
 MAKEFILE_PATH=''
 
@@ -210,7 +210,7 @@ fi
 # Install git.
 if [ $OS == 'ubuntu' ] || [ $OS == 'debian' ]; then
   apt-get install git -y -qq
-        
+
 elif [ $OS == 'centos' ] || [ $OS == 'redhat' ] || [ $OS == 'fedora'  ]; then
     yum install epel-release -y
     yum install git -y

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ if [ $EUID -ne 0 ]; then
 fi
 
 # The rest of the scripts are only cloned if the playbook path option is not found.
-DEVSHOP_GIT_REPO='http://github.com/opendevshop/devshop.git'
+DEVSHOP_GIT_REPO='http://github.com/DropForge-Labs/devshop.git'
 DEVSHOP_SCRIPT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [ -f '/etc/os-release' ]; then

--- a/roles.yml
+++ b/roles.yml
@@ -16,4 +16,4 @@
   version: 1.0.3
 
 - name: opendevshop.devmaster
-  version: 1.1.1
+  version: 7578951c330ab3c50fd0c70c85e65d357de7e65c

--- a/roles.yml
+++ b/roles.yml
@@ -9,11 +9,13 @@
 - name: opendevshop.aegir-user
   version: 1.0.0
 
-- name: git+https://github.com/opendevshop/ansible-role-aegir-apache.git
+- src: https://github.com/opendevshop/ansible-role-aegir-apache.git
   version: 0c5e9f6d3ec94231a32e4b09c7a30b836a490b82
+  name: opendevshop.aegir-apache
 
 - name: opendevshop.aegir-nginx
   version: 1.0.3
 
-- name: git+https://github.com/opendevshop/ansible-role-devmaster.git
+- src: https://github.com/opendevshop/ansible-role-devmaster.git
   version: 7578951c330ab3c50fd0c70c85e65d357de7e65c
+  name: opendevshop.devmaster

--- a/roles.yml
+++ b/roles.yml
@@ -9,11 +9,11 @@
 - name: opendevshop.aegir-user
   version: 1.0.0
 
-- name: opendevshop.aegir-apache
+- name: git+https://github.com/opendevshop/ansible-role-aegir-apache.git
   version: 0c5e9f6d3ec94231a32e4b09c7a30b836a490b82
 
 - name: opendevshop.aegir-nginx
   version: 1.0.3
 
-- name: opendevshop.devmaster
+- name: git+https://github.com/opendevshop/ansible-role-devmaster.git
   version: 7578951c330ab3c50fd0c70c85e65d357de7e65c

--- a/roles.yml
+++ b/roles.yml
@@ -1,16 +1,16 @@
 # Aegir Roles
 
 - name: geerlingguy.php
-  version: 2.0.3
+  version: 3.0.4
 
 - name: geerlingguy.php-mysql
-  version: 1.2.0
-  
+  version: 2.0.0
+
 - name: opendevshop.aegir-user
   version: 1.0.0
 
 - name: opendevshop.aegir-apache
-  version: 1.0.1
+  version: 0c5e9f6d3ec94231a32e4b09c7a30b836a490b82
 
 - name: opendevshop.aegir-nginx
   version: 1.0.3

--- a/roles.yml
+++ b/roles.yml
@@ -9,13 +9,13 @@
 - name: opendevshop.aegir-user
   version: 1.0.0
 
-- src: https://github.com/opendevshop/ansible-role-aegir-apache.git
+- src: https://github.com/rsau/ansible-role-aegir-apache.git
   version: 0c5e9f6d3ec94231a32e4b09c7a30b836a490b82
   name: opendevshop.aegir-apache
 
 - name: opendevshop.aegir-nginx
   version: 1.0.3
 
-- src: https://github.com/opendevshop/ansible-role-devmaster.git
+- src: https://github.com/rsau/ansible-role-devmaster.git
   version: 7578951c330ab3c50fd0c70c85e65d357de7e65c
   name: opendevshop.devmaster


### PR DESCRIPTION
I included changes to roles.yml according to what @jonpugh suggested had worked during his testing.  There were 2 PRs that had implemented his suggestions favoring generic PHP packages:

- https://github.com/opendevshop/ansible-role-devmaster/pull/1
- https://github.com/opendevshop/ansible-role-aegir-apache/pull/2

Temporary change to install.sh line 26 and line 42 which can be updated to proper values during a release.

I tested this script on a VPS host and it successfully installed with 16.04.3.

To replicate with Digital Ocean Fresh VM

* Set sudo password with `passwd`
* Change hostname to fqdn, editing `/etc/hostname` (reboot)
* `cd /root`
* `wget https://raw.githubusercontent.com/DropForge-Labs/devshop/ubuntu-16/install.sh`
* `bash install.sh`