### PR TITLE
Update wget path to fetch install.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added Composer Autoloader module..
 - Added Intercom module in preperation for DevShop support release.
 - Added "--email" option to install.sh to allow for automatic notification of your new DevShop via email.
+- Not successfully released: HybridAuth and Intercom libraries are not whitelisted.
 
 
 ## 1.1.2 (April 26, 2018)


### PR DESCRIPTION
Currently it's set to an older branch that fails on essentially every version of Ubuntu (tested 17.04 and 14.04). Since it's a comment, it could be assumed anyone who reads this would be technical and fetching the latest version would be okay.