### PR TITLE
Adding CAS, HybridAuth, and Intercom Module to the build-devmaster.make file.

### DIFF
--- a/build-devmaster.make
+++ b/build-devmaster.make
@@ -13,3 +13,22 @@ projects[drupal][version] = 7.59
 ; RELEASE
 ; Leave in place for replacement by release process.
 projects[devmaster][version] = 1.x
+
+; CAS
+libraries[cas][download][type] = "git"
+libraries[cas][download][url] = "https://github.com/apereo/phpCAS"
+libraries[cas][download][tag] = "1.3.5"
+libraries[cas][destination] = "libraries"
+
+; Hybrid Auth
+libraries[hybridauth][download][type] = "git"
+libraries[hybridauth][download][url] = "https://github.com/hybridauth/hybridauth"
+libraries[hybridauth][download][tag] = "v2.10.0"
+libraries[hybridauth][destination] = "libraries"
+
+; Intercom Module
+projects[intercomio][type] = module
+projects[intercomio][download][type] = git
+projects[intercomio][download][branch] = composer-autoload
+projects[intercomio][download][url] = "https://github.com/thinkdrop/drupal-intercomio.git"
+projects[intercomio][version] = 1.x


### PR DESCRIPTION
So it occurs to me, only just today, that we can add any libraries we want to devshop installs even if the Drupal.org packaging won't add them to their whitelist!

DevShop (And Aegir) use an auxillary makefile called `build-devmaster.make`. It does not use the Drupal.org package at all, in fact.

We can put extra libraries in that makefile to avoid getting the release of devmaster blocked!