### PR TITLE
Adding ansible roles to `robo prepare:source-code` command.

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -106,6 +106,19 @@ class RoboFile extends \Robo\Tasks {
     'documentation' => 'http://github.com/opendevshop/documentation.git',
     'dockerfiles' => 'http://github.com/opendevshop/dockerfiles.git',
     'aegir-dockerfiles' => 'http://github.com/aegir-project/dockerfiles.git',
+
+    // Ansible roles
+    'roles/geerlingguy.apache' => 'http://github.com/geerlingguy/ansible-role-apache.git',
+    'roles/geerlingguy.composer' => 'http://github.com/geerlingguy/ansible-role-composer.git',
+    'roles/geerlingguy.git' => 'http://github.com/geerlingguy/ansible-role-git.git',
+    'roles/geerlingguy.mysql' => 'http://github.com/geerlingguy/ansible-role-mysql.git',
+    'roles/geerlingguy.nginx' => 'http://github.com/geerlingguy/ansible-role-nginx.git',
+    'roles/geerlingguy.php' => 'http://github.com/geerlingguy/ansible-role-php.git',
+    'roles/geerlingguy.php-mysql' => 'http://github.com/geerlingguy/ansible-role-php-mysql.git',
+    'roles/opendevshop.aegir-apache' => 'http://github.com/opendevshop/ansible-role-aegir-apache',
+    'roles/opendevshop.aegir-nginx' => 'http://github.com/opendevshop/ansible-role-aegir-nginx',
+    'roles/opendevshop.aegir-user' => 'http://github.com/opendevshop/ansible-role-aegir-user',
+    'roles/opendevshop.devmaster' => 'http://github.com/opendevshop/ansible-role-devmaster.git',
   ];
 
   /**

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -106,8 +106,10 @@ class RoboFile extends \Robo\Tasks {
     'documentation' => 'http://github.com/opendevshop/documentation.git',
     'dockerfiles' => 'http://github.com/opendevshop/dockerfiles.git',
     'aegir-dockerfiles' => 'http://github.com/aegir-project/dockerfiles.git',
+  ];
 
-    // Ansible roles
+  // Ansible roles
+  private $roles = [
     'roles/geerlingguy.apache' => 'http://github.com/geerlingguy/ansible-role-apache.git',
     'roles/geerlingguy.composer' => 'http://github.com/geerlingguy/ansible-role-composer.git',
     'roles/geerlingguy.git' => 'http://github.com/geerlingguy/ansible-role-git.git',
@@ -153,6 +155,23 @@ class RoboFile extends \Robo\Tasks {
           ->cloneRepo($url, $path)
           ->run();
       }
+    }
+
+    // If not on travis, clone all ansible roles
+    if (!isset($_SERVER['TRAVIS_REPO_SLUG'])) {
+
+      // @TODO: Detect and clone the right version. This will not be necessary in Ansible 2.6.
+      foreach ($this->roles as $path => $url) {
+        if (file_exists($path)) {
+          $this->say("$path already exists.");
+        }
+        else {
+          $this->taskGitStack()
+            ->cloneRepo($url, $path)
+            ->run();
+        }
+      }
+
     }
 
     // Run drush make to build the devmaster stack.

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -260,6 +260,9 @@ class RoboFile extends \Robo\Tasks {
    * --install-sh-image=geerlingguy/docker-centos7-ansible Launch an OS
    * container, then install devshop using install.sh in a CentOS 7 image.
    *
+   *   robo up --mode=manual
+   *   Just launch the container. Allows you to manually run the install.sh script.
+   *
    * @option $test Run tests after containers are up and devshop is installed.
    * @option $test-upgrade Install an old version, upgrade it to this version,
    *   then run tests.
@@ -353,7 +356,7 @@ class RoboFile extends \Robo\Tasks {
         }
       }
     }
-    elseif ($opts['mode'] == 'install.sh') {
+    elseif ($opts['mode'] == 'install.sh' || $opts['mode'] == 'manual') {
 
       $init_map = [
         'centos:7' => '/usr/lib/systemd/systemd',
@@ -438,7 +441,7 @@ class RoboFile extends \Robo\Tasks {
       # Run install script on the container.
       # @TODO: Run the last version on the container, then upgrade.
       $install_command = '/usr/share/devshop/install.sh ' . $opts['install-sh-options'];
-      if (($this->input()
+      if ($opts['mode'] != 'manual' && ($this->input()
             ->getOption('no-interaction') || $this->confirm('Run install.sh script?')) && !$this->taskDockerExec('devshop_container')
           ->exec($install_command)
           //        ->option('tty')

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -170,7 +170,7 @@ class RoboFile extends \Robo\Tasks {
       }
 
       foreach ($roles as $name => $role) {
-        $path = 'repos/' . $name;
+        $path = 'roles/' . $name;
         if (file_exists($path)) {
           $this->say("$path already exists.");
         }

--- a/roles.yml
+++ b/roles.yml
@@ -19,7 +19,7 @@
   version: 1.0.5
 
 - name: opendevshop.devmaster
-  version: 1.3.0
+  version: master
 
 - name: opendevshop.aegir-user
   version: 1.1.0

--- a/roles.yml
+++ b/roles.yml
@@ -1,7 +1,7 @@
 # Aegir Roles
 
 - name: geerlingguy.php
-  version: 3.5.0
+  version: 3.6.0
 
 - name: geerlingguy.php-mysql
   version: 2.0.1

--- a/roles.yml
+++ b/roles.yml
@@ -13,7 +13,7 @@
   version: 2.8.1
 
 - name: opendevshop.aegir-apache
-  version: 1.1.0
+  version: master
 
 - name: opendevshop.aegir-nginx
   version: 1.0.5

--- a/roles.yml
+++ b/roles.yml
@@ -1,7 +1,7 @@
 # Aegir Roles
 
 - name: geerlingguy.php
-  version: 3.6.0
+  version: 3.5.0
 
 - name: geerlingguy.php-mysql
   version: 2.0.1
@@ -13,13 +13,13 @@
   version: 2.8.1
 
 - name: opendevshop.aegir-apache
-  version: master
+  version: 1.1.0
 
 - name: opendevshop.aegir-nginx
   version: 1.0.5
 
 - name: opendevshop.devmaster
-  version: master
+  version: 1.3.0
 
 - name: opendevshop.aegir-user
   version: 1.1.0


### PR DESCRIPTION
Ansible role development got left in the dust when I switched to robo and docker.

This PR helps make ansible role development easier:

- [x] Git clones the roles to the proper folder during the `robo prepare:source` command.
- [x]  Adds an option for manual install using `robo up --mode=manual`, allowing user to run install script manually.

The main point of this is to try and reproduce #279