### PR TITLE
snapcraft.yaml: Fix syntax of summary field

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
  
 name: devshop
 version: 0.1
-summary: Drupal DevOps Platform: Develop, Test, & Deploy any Drupal site.
+summary: 'Drupal DevOps Platform: Develop, Test, & Deploy any Drupal site.'
 description: |
   DevShop automates Drupal hosting, testing, and deployment. 
   Submit a pull request, get a copy of your site. 


### PR DESCRIPTION
The previous version failed to parse as YAML ("mapping values are not allowed here").