### PR TITLE
Enable HTTPS via letsencrypt by default.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
 
       # To allow the devmaster container to launch other docker containers, we need the host's path to aegir home directory.
       HOST_AEGIR_HOME: /home/jon/Projects/devshop/aegir-home
+      AEGIR_HTTP_SERVICE_TYPE: https_apache
 
     privileged: true
     volumes:

--- a/src/DevShop/Command/InstallDevmaster.php
+++ b/src/DevShop/Command/InstallDevmaster.php
@@ -170,7 +170,7 @@ class InstallDevmaster extends Command
       ->addOption(
         'http_service_type', NULL, InputOption::VALUE_OPTIONAL,
         'The HTTP service to use: apache or nginx',
-        'apache'
+        'https_apache'
       )
 
       // http_port


### PR DESCRIPTION
This requires changing provision. It's hard coded to only allow nginx or apache.