### PR TITLE
Fix build-devmaster.make to use latest git reference

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -665,7 +665,7 @@ class RoboFile extends \Robo\Tasks {
     }
 
     if ($this->confirm("Write '$drupal_org_version' to build-devmaster.make? ")) {
-      $this->_exec("sed -i -e 's/projects\[devmaster\]\[version\] = 1.x/projects[devmaster][version] = $drupal_org_version/' build-devmaster.make");
+      $this->_exec("sed -i -e 's/projects\[devmaster\]\[version\] = 1.x-dev/projects[devmaster][version] = $drupal_org_version/' build-devmaster.make");
     }
 
     if ($this->confirm("Write '$drupal_org_version' to drupal-org.make for devshop_stats? ")) {

--- a/build-devmaster.make
+++ b/build-devmaster.make
@@ -12,15 +12,9 @@ projects[drupal][version] = 7.59
 
 ; RELEASE
 ; Leave in place for replacement by release process.
-projects[devmaster][version] = 1.x
-
-; DEVELOPMENT & TESTING
-; When you need to test or install devshop using a devmaster branch, uncomment this.
-; BE SURE TO COMMENT THIS OUT FOR RELEASE.
-; projects[devmaster][type] = "profile"
-; projects[devmaster][download][type] = "git"
-; projects[devmaster][download][url] = "https://github.com/opendevshop/devmaster"
-; projects[devmaster][download][branch] = "7.x-1.x"
+projects[devmaster][version] = 1.x-dev
+projects[devmaster][type] = "profile"
+projects[devmaster][download][type] = "git"
 
 ; CAS
 libraries[cas][download][type] = "git"


### PR DESCRIPTION

build-devmaster.make does not really work right. The devmaster 1.x version only points at the latest packaged "dev" release, which isn't generated by drupal.org for every commit, so it can get out of date.

This change uses the latest git version of 1.x of devmaster instead.

Updated robofile release command to handle this.