### PR TITLE
fix(install.sh): Add mysql_root_password to ANSIBLE_EXTRA_VARS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -369,6 +369,7 @@ ANSIBLE_EXTRA_VARS+=("playbook_path: ${DEVSHOP_INSTALL_PATH}")
 ANSIBLE_EXTRA_VARS+=("aegir_server_webserver: ${SERVER_WEBSERVER}")
 ANSIBLE_EXTRA_VARS+=("devshop_version: ${DEVSHOP_VERSION}")
 ANSIBLE_EXTRA_VARS+=("aegir_user_uid: ${AEGIR_USER_UID}")
+ANSIBLE_EXTRA_VARS+=("mysql_root_password: ${MYSQL_ROOT_PASSWORD}")
 ANSIBLE_EXTRA_VARS+=("travis: false")
 ANSIBLE_EXTRA_VARS+=("supervisor_running: true")
 


### PR DESCRIPTION
Mysql root pass in .my.cnf is "root" after fresh install on ubuntu 18.04, which is not good.
Looks like we have lost mysql password parameter in: https://github.com/opendevshop/devshop/commit/e305886f965a94818f9136c8a490d53307411a11