### PR TITLE
Add DevShop CLI Bin directory to PATH: Use composer installed drush and add NPM/NODE!

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -421,13 +421,13 @@ class RoboFile extends \Robo\Tasks {
       $env .= !empty($_SERVER['BEHAT_PATH'])? " -e BEHAT_PATH={$_SERVER['BEHAT_PATH']}": '';
 
       if ($opts['test']) {
-        $command = "/bin/bash /usr/share/devshop/tests/devshop-tests.sh";
+        $command = "/usr/bin/env bash /usr/share/devshop/tests/devshop-tests.sh";
         $cmd = "docker-compose -f docker-compose-tests.yml run $env devmaster '$command'";
       }
       elseif ($opts['test-upgrade']) {
         $version = self::UPGRADE_FROM_VERSION;
         $provision_version = self::UPGRADE_FROM_PROVISION_VERSION;
-        $command = "/bin/bash /usr/share/devshop/tests/devshop-tests-upgrade.sh";
+        $command = "/usr/bin/env bash /usr/share/devshop/tests/devshop-tests-upgrade.sh";
 
         // @TODO: Have this detect the branch and use that for the version.
         $root_target = '/var/aegir/devmaster-' . $opts['devshop-version'];

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -422,7 +422,7 @@ class RoboFile extends \Robo\Tasks {
 
       if ($opts['test']) {
         $command = "/usr/share/devshop/tests/devshop-tests.sh";
-        $cmd = "docker-compose -f docker-compose-tests.yml run -T $env devmaster '$command'";
+        $cmd = "docker-compose -f docker-compose-tests.yml run $env devmaster '$command'";
       }
       elseif ($opts['test-upgrade']) {
         $version = self::UPGRADE_FROM_VERSION;

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -421,13 +421,13 @@ class RoboFile extends \Robo\Tasks {
       $env .= !empty($_SERVER['BEHAT_PATH'])? " -e BEHAT_PATH={$_SERVER['BEHAT_PATH']}": '';
 
       if ($opts['test']) {
-        $command = "bash /usr/share/devshop/tests/devshop-tests.sh";
+        $command = "/bin/bash /usr/share/devshop/tests/devshop-tests.sh";
         $cmd = "docker-compose -f docker-compose-tests.yml run $env devmaster '$command'";
       }
       elseif ($opts['test-upgrade']) {
         $version = self::UPGRADE_FROM_VERSION;
         $provision_version = self::UPGRADE_FROM_PROVISION_VERSION;
-        $command = "bash /usr/share/devshop/tests/devshop-tests-upgrade.sh";
+        $command = "/bin/bash /usr/share/devshop/tests/devshop-tests-upgrade.sh";
 
         // @TODO: Have this detect the branch and use that for the version.
         $root_target = '/var/aegir/devmaster-' . $opts['devshop-version'];

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -421,13 +421,13 @@ class RoboFile extends \Robo\Tasks {
       $env .= !empty($_SERVER['BEHAT_PATH'])? " -e BEHAT_PATH={$_SERVER['BEHAT_PATH']}": '';
 
       if ($opts['test']) {
-        $command = "/usr/bin/env bash /usr/share/devshop/tests/devshop-tests.sh";
-        $cmd = "docker-compose -f docker-compose-tests.yml run $env devmaster '$command'";
+        $command = "/usr/share/devshop/tests/devshop-tests.sh";
+        $cmd = "docker-compose -f docker-compose-tests.yml run -T $env devmaster '$command'";
       }
       elseif ($opts['test-upgrade']) {
         $version = self::UPGRADE_FROM_VERSION;
         $provision_version = self::UPGRADE_FROM_PROVISION_VERSION;
-        $command = "/usr/bin/env bash /usr/share/devshop/tests/devshop-tests-upgrade.sh";
+        $command = "/usr/share/devshop/tests/devshop-tests-upgrade.sh";
 
         // @TODO: Have this detect the branch and use that for the version.
         $root_target = '/var/aegir/devmaster-' . $opts['devshop-version'];

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -502,7 +502,7 @@ class RoboFile extends \Robo\Tasks {
         ->env('TRAVIS_REPO_SLUG', $_SERVER['TRAVIS_REPO_SLUG'])
         ->env('TRAVIS_PULL_REQUEST_BRANCH', $_SERVER['TRAVIS_PULL_REQUEST_BRANCH'])
         ->env('AEGIR_USER_UID', $opts['user-uid'])
-        ->env('PATH', "/usr/share/devshop/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+        ->env('PATH', "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/share/devshop/bin")
         ->exec('/usr/share/devshop/tests/run-tests.sh')
         ->exec($init)
         ->run()

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -502,6 +502,7 @@ class RoboFile extends \Robo\Tasks {
         ->env('TRAVIS_REPO_SLUG', $_SERVER['TRAVIS_REPO_SLUG'])
         ->env('TRAVIS_PULL_REQUEST_BRANCH', $_SERVER['TRAVIS_PULL_REQUEST_BRANCH'])
         ->env('AEGIR_USER_UID', $opts['user-uid'])
+        ->env('PATH', "/usr/share/devshop/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
         ->exec('/usr/share/devshop/tests/run-tests.sh')
         ->exec($init)
         ->run()
@@ -535,6 +536,7 @@ class RoboFile extends \Robo\Tasks {
             ->wasSuccessful()
         )) {
           $this->say('Unable to install dbus. Setting hostname wont work. See https://github.com/ansible/ansible/issues/25543');
+
           exit(1);
         }
       }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -421,13 +421,13 @@ class RoboFile extends \Robo\Tasks {
       $env .= !empty($_SERVER['BEHAT_PATH'])? " -e BEHAT_PATH={$_SERVER['BEHAT_PATH']}": '';
 
       if ($opts['test']) {
-        $command = "/usr/share/devshop/tests/devshop-tests.sh";
+        $command = "bash /usr/share/devshop/tests/devshop-tests.sh";
         $cmd = "docker-compose -f docker-compose-tests.yml run $env devmaster '$command'";
       }
       elseif ($opts['test-upgrade']) {
         $version = self::UPGRADE_FROM_VERSION;
         $provision_version = self::UPGRADE_FROM_PROVISION_VERSION;
-        $command = "/usr/share/devshop/tests/devshop-tests-upgrade.sh";
+        $command = "bash /usr/share/devshop/tests/devshop-tests-upgrade.sh";
 
         // @TODO: Have this detect the branch and use that for the version.
         $root_target = '/var/aegir/devmaster-' . $opts['devshop-version'];

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "cpliakas/git-wrapper": "1.*",
         "asm/php-ansible": "v1.2.0",
         "consolidation/robo": "^1",
-        "drush/drush": "~8.1"
+        "drush/drush": "~8.1",
+        "mouf/nodejs-installer": "^1.0"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4cb9eb48f12124dd38e6d39dd8ca756",
+    "content-hash": "81657f06a84584bcc4e09e49c31606b8",
     "packages": [
         {
             "name": "asm/php-ansible",
@@ -1152,6 +1152,62 @@
                 "service"
             ],
             "time": "2017-05-10T09:20:27+00:00"
+        },
+        {
+            "name": "mouf/nodejs-installer",
+            "version": "v1.0.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/nodejs-installer.git",
+                "reference": "e9bc2e7c75665913dd73dc4765b40757e6796ee8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/nodejs-installer/zipball/e9bc2e7c75665913dd73dc4765b40757e6796ee8",
+                "reference": "e9bc2e7c75665913dd73dc4765b40757e6796ee8",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "ext-openssl": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": [
+                    "Mouf\\NodeJsInstaller\\NodeJsPlugin"
+                ],
+                "mouf": {
+                    "logo": "node-js.png"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mouf\\NodeJsInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Négrier",
+                    "email": "d.negrier@thecodingmachine.com",
+                    "homepage": "http://mouf-php.com"
+                }
+            ],
+            "description": "An installer package that let's you install NodeJS and NPM as a Composer dependency.",
+            "homepage": "http://mouf-php.com/packages/mouf/nodejs-installer",
+            "keywords": [
+                "installer",
+                "nodejs",
+                "npm"
+            ],
+            "time": "2018-04-16T16:03:09+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -26,6 +26,9 @@ services:
       # To allow the devmaster container to launch other docker containers, we need the host's path to aegir home directory.
       HOST_AEGIR_HOME: /home/jon/Projects/devshop/aegir-home
 
+      # Make sure devshop CLI is in the PATH.
+      PATH: "/usr/share/devshop/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
     privileged: true
     volumes:
       - ./aegir-home:/var/aegir:z

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -27,7 +27,7 @@ services:
       HOST_AEGIR_HOME: /home/jon/Projects/devshop/aegir-home
 
       # Make sure devshop CLI is in the PATH.
-      PATH: "/usr/share/devshop/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/share/devshop/bin"
 
     privileged: true
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
       # To allow the devmaster container to launch other docker containers, we need the host's path to aegir home directory.
       HOST_AEGIR_HOME: /home/jon/Projects/devshop/aegir-home
-
+      PATH: "/usr/share/devshop/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       # @TODO: We can't define the service type here.
       # The Provision classes for this service type MUST be available in
       # provision project, because at this point, the devmaster site might not

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
       # To allow the devmaster container to launch other docker containers, we need the host's path to aegir home directory.
       HOST_AEGIR_HOME: /home/jon/Projects/devshop/aegir-home
-      PATH: "/usr/share/devshop/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/share/devshop/bin"
       # @TODO: We can't define the service type here.
       # The Provision classes for this service type MUST be available in
       # provision project, because at this point, the devmaster site might not

--- a/install.sh
+++ b/install.sh
@@ -403,6 +403,8 @@ set -e
 # Version used for cloning devshop playbooks
 # Must be a branch or tag.
 DEVSHOP_VERSION=1.x
+# @TODO: Remove when PR Passes.
+DEVSHOP_VERSION=devshop-bin
 DEVSHOP_INSTALL_PATH=/usr/share/devshop
 SERVER_WEBSERVER=apache
 MAKEFILE_PATH=''

--- a/roles.yml
+++ b/roles.yml
@@ -28,7 +28,7 @@
   version: 1.5.0-rc1
 
 - name: opendevshop.devmaster
-  version: 1.5.0-rc7
+  version: devshop-bin
 
 - name: opendevshop.aegir-user
   version: 1.5.0-rc7

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -3,6 +3,8 @@
 set -e
 
 echo ">> ENV on devshop-tests.sh:"
+
+export SHELL=/bin/bash
 env
 
 # Print the lines and exit if a failure happens.

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -2,14 +2,6 @@
 
 set -e
 
-# confirm devshop, drush, npm and node are executable.
-set +x
-devshop --version
-drush --version
-node --version
-npm --version
-set -x
-
 # Run remaining tasks from install process.
 
 echo ">> Verify hostmaster platform first."

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -3,11 +3,6 @@
 set -e
 
 echo ">> ENV on devshop-tests.sh:"
-
-export SHELL=/bin/bash
-export USER=aegir
-export LOGNAME=aegir
-export NVM_BIN=""
 env
 
 # Print the lines and exit if a failure happens.

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -3,12 +3,10 @@
 set -e
 
 # Print the lines and exit if a failure happens.
-set -x
 /usr/share/devshop/bin/devshop --version
 /usr/share/devshop/bin/drush --version
 /usr/share/devshop/bin/node --version
 /usr/share/devshop/bin/npm --version
-set +x
 
 # Run remaining tasks from install process.
 

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -7,7 +7,7 @@ echo ">> ENV on devshop-tests.sh:"
 export SHELL=/bin/bash
 export USER=aegir
 export LOGNAME=aegir
-
+export NVM_BIN=""
 env
 
 # Print the lines and exit if a failure happens.

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -9,8 +9,13 @@ env
 echo ">> Checking versions of devshop, drush, node, npm..."
 /usr/share/devshop/bin/devshop --version
 /usr/share/devshop/bin/drush --version
-node --version
-npm --version
+
+# @TODO: These commands fail when using the docker-compose based test suites.
+# See https://travis-ci.org/opendevshop/devshop/jobs/529898435#L2196
+if [ -v $TRAVIS ]; then
+    node --version
+    npm --version
+fi
 
 # Run remaining tasks from install process.
 

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+echo ">> ENV on devshop-tests.sh:"
+env
+
 # Print the lines and exit if a failure happens.
 echo ">> Checking versions of devshop, drush, node, npm..."
 /usr/share/devshop/bin/devshop --version

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+# confirm devshop, drush, npm and node are executable.
+set +x
+devshop --version
+drush --version
+node --version
+npm --version
+set -x
+
 # Run remaining tasks from install process.
 
 echo ">> Verify hostmaster platform first."

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -9,8 +9,8 @@ env
 echo ">> Checking versions of devshop, drush, node, npm..."
 /usr/share/devshop/bin/devshop --version
 /usr/share/devshop/bin/drush --version
-/usr/share/devshop/bin/node --version
-/usr/share/devshop/bin/npm --version
+node --version
+npm --version
 
 # Run remaining tasks from install process.
 

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -6,6 +6,8 @@ echo ">> ENV on devshop-tests.sh:"
 
 export SHELL=/bin/bash
 export USER=aegir
+export LOGNAME=aegir
+
 env
 
 # Print the lines and exit if a failure happens.

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+# Print the lines and exit if a failure happens.
+set -x
+/usr/share/devshop/bin/devshop --version
+/usr/share/devshop/bin/drush --version
+/usr/share/devshop/bin/node --version
+/usr/share/devshop/bin/npm --version
+set +x
+
 # Run remaining tasks from install process.
 
 echo ">> Verify hostmaster platform first."

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -3,6 +3,7 @@
 set -e
 
 # Print the lines and exit if a failure happens.
+echo ">> Checking versions of devshop, drush, node, npm..."
 /usr/share/devshop/bin/devshop --version
 /usr/share/devshop/bin/drush --version
 /usr/share/devshop/bin/node --version

--- a/tests/devshop-tests.sh
+++ b/tests/devshop-tests.sh
@@ -5,6 +5,7 @@ set -e
 echo ">> ENV on devshop-tests.sh:"
 
 export SHELL=/bin/bash
+export USER=aegir
 env
 
 # Print the lines and exit if a failure happens.


### PR DESCRIPTION
DevShop CLI  is a composer app. We can include drush as a dependency so we don't need to install it in other ways.

If the DevShop CLI BIN dir is included in the path, we get all the tools loaded with composer installed globally!

By requiring mouf/nodejs-installer, we get Node and NPM installed super easily!