### PR TITLE
Add www.amsa.gov.au as a previous user

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -18,4 +18,5 @@ Thanks!
 | [thinkdrop.net](https://thinkdrop.net)  | Homepage of the creator, Jon Pugh | 2012
 | [ryanpricemedia.com](http://ryanpricemedia.com) | Homepage of Ryan Price, co-host of the DrupalEasy Podcast | 2016
 | [justjazz.tv](http://www.justjazz.tv/) | Home of the indie radio, tv, and events network, Just Jazz | 2018
+| [www.amsa.gov.au](https://www.amsa.gov.au) | Australian Maritime Safety Authority, government website | Used for production & development from 2017-2019
 | [Your Site Here](https://yoururl)  |  A brief description of the owner or purpose of the site.      | The approximate date launched.  |


### PR DESCRIPTION
Just adding www.amsa.gov.au (Australian Maritime Safety Authority) as a previous user of DevShop for production and development from mid 2017 to early 2019.