### PR TITLE
Makefile fixes for easier development

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -158,6 +158,14 @@ class RoboFile extends \Robo\Tasks {
           ->cloneRepo($url, $this->devshop_root_path . '/' . $path)
           ->run();
       }
+
+      // Checkout provision to the 7.x-3.x-devshop branch.
+      if ($path == 'provision') {
+        $this->taskGitStack()
+          ->dir($this->devshop_root_path . '/' . $path)
+          ->checkout('7.x-3.x-devshop')
+          ->run();
+      }
     }
 
     // @TODO: Detect and clone the right version. This will not be necessary in Ansible 2.6.

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -435,6 +435,7 @@ class RoboFile extends \Robo\Tasks {
         'ubuntu:14.04' => '/sbin/init',
         'geerlingguy/docker-ubuntu1404-ansible' => '/sbin/init',
         'geerlingguy/docker-ubuntu1604-ansible' => '/lib/systemd/systemd',
+        'geerlingguy/docker-ubuntu1804-ansible' => '/lib/systemd/systemd',
         'geerlingguy/docker-centos7-ansible' => '/usr/lib/systemd/systemd',
       ];
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -461,6 +461,7 @@ class RoboFile extends \Robo\Tasks {
         ->volume($this->devshop_root_path, '/usr/share/devshop')
         ->volume($this->devshop_root_path . '/aegir-home', '/var/aegir')
         ->volume($this->devshop_root_path . '/roles', '/etc/ansible/roles')
+        ->volume($this->devshop_root_path . '/provision', '/var/aegir/.drush/commands/provision')
         ->option('--hostname', 'devshop.local.computer')
         ->option('--add-host', '"' . $_SERVER['SITE_HOSTS'] . '":127.0.0.1')
         ->option('--volume', '/sys/fs/cgroup:/sys/fs/cgroup:ro')

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -4,7 +4,7 @@ api: "2"
 
 defaults:
   projects:
-    subdir: "aegir"
+    subdir: "contrib"
 
 projects:
   drupal:
@@ -79,6 +79,85 @@ projects:
     download:
       type: git
       branch: 7.x-1.x
+
+  admin_menu:
+    download:
+      type: git
+  adminrole:
+    download:
+      type: git
+  betterlogin:
+    download:
+      type: git
+  cas:
+    download:
+      type: git
+  cas_attributes:
+    download:
+      type: git
+  chosen:
+    download:
+      type: git
+  composer_manager:
+    download:
+      type: git
+  ctools:
+    download:
+      type: git
+  distro_update:
+    download:
+      type: git
+  entity:
+    download:
+      type: git
+  features:
+    download:
+      type: git
+  hosting_statsd:
+    download:
+      type: git
+  intercomio:
+    download:
+      type: git
+  jquery_update:
+    download:
+      type: git
+  libraries:
+    download:
+      type: git
+  module_filter:
+    download:
+      type: git
+  navbar:
+    download:
+      type: git
+  openidadmin:
+    download:
+      type: git
+  overlay_paths:
+    download:
+      type: git
+  r4032login:
+    download:
+      type: git
+  sshkey:
+    download:
+      type: git
+  statsd:
+    download:
+      type: git
+  timeago:
+    download:
+      type: git
+  token:
+    download:
+      type: git
+  views:
+    download:
+      type: git
+  views_bulk_operations:
+    download:
+      type: git
 
 libraries:
 

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -33,7 +33,7 @@ projects:
   hosting_git:
     download:
       type: git
-      tag: 7.x-3.180
+      tag: 7.x-3.181
 
   hosting_remote_import:
     download:

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -83,81 +83,127 @@ projects:
   admin_menu:
     download:
       type: git
+      branch: 7.x-1.x
+
   adminrole:
     download:
       type: git
+      branch: 7.x-3.x
+
   betterlogin:
     download:
       type: git
+      branch: 7.x-1.x
+
   cas:
     download:
       type: git
+      branch: 7.x-1.x
+
   cas_attributes:
     download:
       type: git
+      branch: 7.x-1.x
+
   chosen:
     download:
       type: git
+      branch: 7.x-2.x
+
   composer_manager:
     download:
       type: git
+      branch: 7.x-1.x
+
   ctools:
     download:
       type: git
-  distro_update:
-    download:
-      type: git
+      branch: 7.x-1.x
+
   entity:
     download:
       type: git
+      branch: 7.x-1.x
+
   features:
     download:
       type: git
+      branch: 7.x-2.x
+
   hosting_statsd:
     download:
       type: git
+      branch: 7.x-1.x
+
   intercomio:
     download:
       type: git
+      branch: 7.x-1.x
+
   jquery_update:
     download:
       type: git
+      branch: 7.x-3.x
+
   libraries:
     download:
       type: git
+      branch: 7.x-2.X
+
   module_filter:
     download:
       type: git
+      branch: 7.x-2.x
+
   navbar:
     download:
       type: git
+      branch: 7.x-1.x
+
   openidadmin:
     download:
       type: git
+      branch: 7.x-1.x
+
   overlay_paths:
     download:
       type: git
+      branch: 7.x-1.x
+
   r4032login:
     download:
       type: git
+      branch: 7.x-1.x
+
   sshkey:
     download:
       type: git
+      branch: 7.x-2.x
+
   statsd:
     download:
       type: git
+      branch: 7.x-1.x
+
   timeago:
     download:
       type: git
+      branch: 7.x-2.x
+
   token:
     download:
       type: git
+      branch: 7.x-1.x
+
   views:
     download:
       type: git
+      branch: 7.x-3.x
+
   views_bulk_operations:
     download:
       type: git
+      branch: 7.x-3.x
 
 libraries:
 

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -110,6 +110,8 @@ projects:
     download:
       type: git
       tag: 7.x-1.7
+    patch:
+      - https://www.drupal.org/files/issues/2018-12-13/3020349-cas-library-path.patch
 
   cas_attributes:
     download:

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -28,7 +28,7 @@ projects:
   hosting:
     download:
       type: git
-      tag: 7.x-3.180
+      tag: 7.x-3.180-devshop
 
   hosting_git:
     download:

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -83,12 +83,12 @@ projects:
   admin_menu:
     download:
       type: git
-      branch: 7.x-1.x
+      branch: 7.x-3.x
 
   adminrole:
     download:
       type: git
-      branch: 7.x-3.x
+      branch: 7.x-1.x
 
   betterlogin:
     download:

--- a/build-devmaster-dev.make.yml
+++ b/build-devmaster-dev.make.yml
@@ -22,54 +22,65 @@ projects:
   devel:
     version: 1
 
+  # The modules listed below override the settings in devmaster/drupal-org.make
+  # Each module is downloaded and checked out to the version specified here.
+  # These
   hosting:
     download:
       type: git
-      branch: 7.x-3.x-devshop
+      tag: 7.x-3.180
 
   hosting_git:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.180
 
   hosting_remote_import:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.180
 
   hosting_site_backup_manager:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.180
 
   hosting_tasks_extra:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.180
+
   hosting_filemanager:
     download:
       type: git
       branch: 7.x-1.x
+
   hosting_logs:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.181
+
   hosting_https:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.182
+
   aegir_ssh:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.0
+
   aegir_config:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.00-beta1
+
+  # @TODO: Tag releases of submodules.
   aegir_ansible:
     download:
       type: git
       branch: 7.x-1.x
+
   aegir_cloud:
     download:
       type: git
@@ -83,127 +94,127 @@ projects:
   admin_menu:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.0-rc6
 
   adminrole:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.1
 
   betterlogin:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.5
 
   cas:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.7
 
   cas_attributes:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.0-rc3
 
   chosen:
     download:
       type: git
-      branch: 7.x-2.x
+      tag: 7.x-2.1
 
   composer_manager:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.8
 
   ctools:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.15
 
   entity:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.9
 
   features:
     download:
       type: git
-      branch: 7.x-2.x
+      tag: 7.x-2.11
 
   hosting_statsd:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.0-beta1
 
   intercomio:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.0-beta2
 
   jquery_update:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.0-alpha5
 
   libraries:
     download:
       type: git
-      branch: 7.x-2.X
+      tag: 7.x-2.5
 
   module_filter:
     download:
       type: git
-      branch: 7.x-2.x
+      tag: 7.x-2.2
 
   navbar:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.7
 
   openidadmin:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.0
 
   overlay_paths:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.3
 
   r4032login:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.8
 
   sshkey:
     download:
       type: git
-      branch: 7.x-2.x
+      tag: 7.x-2.0
 
   statsd:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.1
 
   timeago:
     download:
       type: git
-      branch: 7.x-2.x
+      tag: 7.x-2.3
 
   token:
     download:
       type: git
-      branch: 7.x-1.x
+      tag: 7.x-1.7
 
   views:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.23
 
   views_bulk_operations:
     download:
       type: git
-      branch: 7.x-3.x
+      tag: 7.x-3.5
 
 libraries:
 

--- a/devmaster/devmaster.make
+++ b/devmaster/devmaster.make
@@ -1,8 +1,13 @@
+;
+; devmaster.make
+;
+; This file is to ensure devmaster's requirements are loaded automatically when
+; another makefiles requires "devmaster".
+;
+; This is how drush make behaves for install profiles: if a PROJECTNAME.make
+; file is found, it loads it into the build.
+
 core = 7.x
 api = 2
 
-; Includes
-
-; This makefile will make sure we get the development code from the Aegir
-; modules instead of the tagged releases.
 includes[devmaster] = drupal-org.make

--- a/devmaster/drupal-org.make
+++ b/devmaster/drupal-org.make
@@ -12,14 +12,13 @@ projects[devshop_stats][version] = 1.x
 ; For release, use tagged version
 projects[hosting][version] = "3.x"
 projects[hosting][download][type] = git
-projects[hosting][download][branch] = 7.x-3.x-devshop
+projects[hosting][download][branch] = 7.x-3.180-devshop
 
 ; Aegir Core not included in hosting.module
 projects[eldir][type] = theme
 projects[eldir][version] = "3.180"
 
-projects[hosting_git][download][type] = git
-projects[hosting_git][download][branch] = 7.x-3.x
+projects[hosting_git][vesrion] = "3.181"
 
 projects[hosting_https][version] = "3.182"
 
@@ -33,9 +32,9 @@ projects[hosting_logs][version] = "3.181"
 
 projects[hosting_filemanager][version] = "1.x"
 
-projects[aegir_ssh][version] = 1.0
+projects[aegir_ssh][version] = "1.0"
 
-projects[aegir_config][version] = 1.x
+projects[aegir_config][version] = "1.x"
 
 projects[aegir_ansible][version] = "1.x"
 

--- a/devmaster/drupal-org.make
+++ b/devmaster/drupal-org.make
@@ -6,12 +6,10 @@ defaults[projects][type] = "module"
 
 ; Update this with each new release of devshop
 projects[devshop_stats][version] = 1.x
-projects[devshop_stats][subdir] = "contrib"
 
 ; Aegir Modules
 ; For development, use latest branch.
 ; For release, use tagged version
-projects[hosting][subdir] = aegir
 projects[hosting][version] = "3.x"
 projects[hosting][download][type] = git
 projects[hosting][download][branch] = 7.x-3.x-devshop
@@ -20,38 +18,27 @@ projects[hosting][download][branch] = 7.x-3.x-devshop
 projects[eldir][type] = theme
 projects[eldir][version] = "3.180"
 
-projects[hosting_git][subdir] = aegir
 projects[hosting_git][download][type] = git
 projects[hosting_git][download][branch] = 7.x-3.x
 
-projects[hosting_https][subdir] = aegir
 projects[hosting_https][version] = "3.182"
 
-projects[hosting_remote_import][subdir] = aegir
 projects[hosting_remote_import][version] = "3.180"
 
-projects[hosting_site_backup_manager][subdir] = aegir
 projects[hosting_site_backup_manager][version] = "3.180"
 
-projects[hosting_tasks_extra][subdir] = aegir
 projects[hosting_tasks_extra][version] = "3.180"
 
-projects[hosting_logs][subdir] = aegir
 projects[hosting_logs][version] = "3.181"
 
-projects[hosting_filemanager][subdir] = aegir
 projects[hosting_filemanager][version] = "1.x"
 
-projects[aegir_ssh][subdir] = aegir
 projects[aegir_ssh][version] = 1.0
 
-projects[aegir_config][subdir] = aegir
 projects[aegir_config][version] = 1.x
 
-projects[aegir_ansible][subdir] = aegir
 projects[aegir_ansible][version] = "1.x"
 
-projects[aegir_cloud][subdir] = aegir
 projects[aegir_cloud][version] = "1.x"
 
 ; Not working yet.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     privileged: true
     volumes:
       - ./aegir-home:/var/aegir:delegated
+      - ./devmaster:/var/aegir/devmaster-1.x/profiles/devmaster:delegated
       - ./:/usr/share/devshop:delegated
       - ./provision:/usr/share/drush/commands/provision:delegated
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Changes to the makefiles so that all contributed code goes into `sites/all/modules/contrib`.

This also allows us to mount the `./devmaster` folder to `/var/aegir/devmaster-1.x/profiles/devmaster` folder so that we don't have to move the code around! Just edit `./devmaster` and the changes are visible in the container.