### PR TITLE
Ops / build / robo-build-local / Add  --local option to robo build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,8 @@ jobs:
     - name: Install Composer dependencies
       run: composer install --prefer-dist --no-progress --no-suggest
 
-    - name: Create local DevShop Server Image
-      run: bin/robo prepare:containers --local -v  --os-version=${{ matrix.os_version }}
+    - name: Create DevShop Server Image FROM devshop/server:latest
+      run: bin/robo prepare:containers -v --os-version=${{ matrix.os_version }}
 
     - name: Prepare Docker Environment with GitHub Variables
       run: env | grep GITHUB_ > .ci.env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,8 @@ jobs:
     - name: Install Composer dependencies
       run: composer install --prefer-dist --no-progress --no-suggest
 
-    - name: Create DevShop Server Image
-      run: bin/robo prepare:containers -v
+    - name: Create local DevShop Server Image
+      run: bin/robo prepare:containers --local -v
 
     - name: Prepare Docker Environment with GitHub Variables
       run: env | grep GITHUB_ > .ci.env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
  push:
    branches:
      - "*"
+     - "ops/*"
  schedule:
   - cron: "10 * * * *"
 jobs:

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -1,4 +1,9 @@
-FROM devshop/server:latest
+
+ARG DEVSHOP_DOCKER_FROM_IMAGE_NAME=devshop/server
+ARG DEVSHOP_DOCKER_FROM_IMAGE_TAG=latest
+
+FROM $DEVSHOP_DOCKER_FROM_IMAGE_NAME:$DEVSHOP_DOCKER_FROM_IMAGE_TAG
+
 LABEL maintainer="Jon Pugh"
 
 # Any Build args that are desired in this Dockerfile must exist here, even if they are in the main Dockerfile.

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -329,6 +329,7 @@ class RoboFile extends \Robo\Tasks {
     'full' => FALSE,
     'local' => FALSE,
     'dockerfile' => 'Dockerfile.fast',
+    'os-version' => 'ubuntu1804',
   ]) {
 
     $this->yell('Building DevShop Container from: ' . $opts['os-version'], 40, 'blue');

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -365,7 +365,7 @@ class RoboFile extends \Robo\Tasks {
 
     // If --full is not set, rebuild the container FROM devshop/server:local.
     elseif (!$this->taskDockerBuild()
-      ->option("--file Dockerfile.${opts['dockerfile']}")
+      ->option("--file ${opts['dockerfile']}")
       ->tag($image_new_tag)
 
       // Hostname should match server_hostname in playbook.server.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,11 @@ services:
 
     privileged: true
     volumes:
-      - ./aegir-home:/var/aegir:delegated
-      - ./devmaster:/var/aegir/devmaster  #-1.x/profiles/devmaster:delegated
+      - ./aegir-home/.drush:/var/aegir/.drush:delegated
+      - ./aegir-home/config:/var/aegir/config:delegated
+      - ./aegir-home/projects:/var/aegir/projects:delegated
+      - ./devmaster:/var/aegir/devmaster-1.x/profiles/devmaster:delegated
+
       - ./:/usr/share/devshop:delegated
       - ./provision:/usr/share/drush/commands/provision:delegated
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Make local container building more explicit by using a `--local` option. 

The `--local` option means the docker build requires the `devshop/server:local` container to exist first.

Without it, the containers are built `FROM devshop/server:latest` which is must faster.


