### PR TITLE
Dev / GitHub / PR queue fixes

### DIFF
--- a/devmaster/modules/devshop/devshop_github/devshop_github.install
+++ b/devmaster/modules/devshop/devshop_github/devshop_github.install
@@ -81,7 +81,7 @@ function devshop_github_schema() {
  */
 function devshop_github_install() {
 
-    // Push devshop_github's system weight to 1.
+    // Push devshop_github system weight to 1.
     db_update('system')
         ->fields(array(
             'weight' => 2
@@ -90,8 +90,8 @@ function devshop_github_install() {
         ->execute();
 
     // Load the token from ENV variable if there is one.
-    if ($token = devshop_github_token()) {
-
+    $token = devshop_github_token();
+    if (!empty($token)) {
       if (devshop_github_token_is_valid($token)) {
         variable_set('devshop_github_token', $token);
         drupal_set_message(t('GitHub token was found and saved. Visit !link to check settings.', array(

--- a/devmaster/modules/devshop/devshop_github/devshop_github.module
+++ b/devmaster/modules/devshop/devshop_github/devshop_github.module
@@ -1844,11 +1844,11 @@ function devshop_github_create_all_pr_environments($project_node) {
 
     // Get PR ID, if it already has one.
     if (!empty($environment->github_pull_request->number)) {
-      $environment_pr_id = $environment->github_pull_request->number;
-      $environment_pr_slug = "pr{$environment_pr_id}";
+      $environment_pr_number = $environment->github_pull_request->number;
+      $environment_pr_slug = "pr{$environment_pr_number}";
     }
     else {
-      $environment_pr_id = NULL;
+      $environment_pr_number = NULL;
       $environment_pr_slug = NULL;
     }
 
@@ -1856,12 +1856,12 @@ function devshop_github_create_all_pr_environments($project_node) {
     drush_log("Checking $environment->name... [$site_url]");
 
     // If no PR data in environment and no PR exists with this environments name, it is not a PR environment. Move on.
-    if ($environment->site_status != HOSTING_SITE_DELETED && empty($environment->github_pull_request->pull_request_object->id) && empty($prs[$environment_pr_slug])) {
+    if ($environment->site_status != HOSTING_SITE_DELETED && empty($environment->github_pull_request) && empty($prs[$environment_pr_slug])) {
       continue;
     }
     // If no PR data, but the environment name matches a PR's slug, update data.
     // Handles the edge case where a pr123 environment lost it's github PR info.
-    elseif (!$environment_pr_id && !empty($prs[$environment->name])) {
+    elseif (!$environment_pr_number && !empty($prs[$environment->name])) {
       devshop_github_save_pr_env_data($prs[$environment->name], $environment);
       drush_log(
         "Environment found with the name '$environment->name'. Assuming it is a PR environment. Updating it with PR data and removing it from the list of environments to create. [$site_url]",
@@ -1870,7 +1870,7 @@ function devshop_github_create_all_pr_environments($project_node) {
       unset($prs_to_create_environments_for[$environment->name]);
     }
     // If there IS PR data in the environment and the PR exists on GitHub, update the PR data.
-    elseif ($environment_pr_id && !empty($prs[$environment_pr_slug])) {
+    elseif ($environment_pr_number && !empty($prs[$environment_pr_slug])) {
       devshop_github_save_pr_env_data($prs[$environment_pr_slug], $environment);
       drush_log("PR environment found and updated: $environment->name [$site_url]", "ok");
 
@@ -1881,8 +1881,8 @@ function devshop_github_create_all_pr_environments($project_node) {
     }
 
     // If there IS PR data on this environment but the PR does NOT exist, queue the site for deletion.
-    elseif ($environment_pr_id && empty($prs[$environment_pr_slug])) {
-      drush_log("PR $environment_pr_id environment $environment->name exists but PR has been closed. [$site_url] [PR Slug $environment_pr_slug]", "ok");
+    elseif ($environment_pr_number && empty($prs[$environment_pr_slug])) {
+      drush_log("PR $environment_pr_number environment $environment->name exists but PR has been closed. [$site_url] [PR Slug $environment_pr_slug]", "ok");
       if ($project->settings->github['pull_request_environments_delete'] && empty($environment->tasks['delete'])) {
         drush_log("PR environment scheduled for deletion: $environment->name [$site_url]", "ok");
         hosting_add_task($environment->site, 'delete', array('force' => 1));


### PR DESCRIPTION
RE https://github.com/opendevshop/devshop/issues/462

1. [x] Switch the logic in "devshop_github_client()" to use a "must authenticate" parameter. This way we know the caller requires a token when we throw an exception for an empty one.
2. [ ] Check the Git Remote AND the SHA before triggering a deploy task.
3. [ ] Duplicate entries/attempts to insert for PR environments.
4. [ ] Create a Behat test to confirm PR environment creation and deployments.
