### PR TITLE
Ops / Scripts / Wait-For Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin/*
 !bin/docker*
 !bin/hosting-queue-runner
 !bin/mysql-wait
+!bin/wait
 
 # Symfony code
 vendor

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ bin/*
 !bin/docker*
 !bin/hosting-queue-runner
 !bin/mysql-wait
-!bin/wait
+!bin/wait-for
 
 # Symfony code
 vendor

--- a/bin/mysql-wait
+++ b/bin/mysql-wait
@@ -1,22 +1,26 @@
 #!/bin/bash
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PATH="$PATH:$DIR"
 
 log() {
   echo "DevShop | mysql-wait | $@";
 }
 
-# Returns true once mysql can connect.
-# Thanks to http://askubuntu.com/questions/697798/shell-script-how-to-run-script-after-mysql-is-ready
-
-mysql_wait() {
-    mysqladmin ping --host=$DATABASE_HOST --user=root --password=$MYSQL_ROOT_PASSWORD > /dev/null 2>&1
-}
+if [ -z "${DATABASE_HOST}" ]; then
+  log "No DATABASE_HOST variable found. Unable to check for database."
+  exit 1
+fi
 
 log "Checking database server $DATABASE_HOST ..."
 
-while ! (mysql_wait)
-do
-   sleep 1
-   echo "Waiting for database host '$DATABASE_HOST' ..."
-done
 
-echo "DevShop | Database active! Checking for Hostmaster Install..."
+# Returns true once mysql can connect.
+# Thanks to http://askubuntu.com/questions/697798/shell-script-how-to-run-script-after-mysql-is-ready
+# Set SILENT=1 to tell `wait-for` script not to print the command.
+# DO NOT CHANGE unless you want to expose MYSQL_ROOT_PASSWORD in your logs.
+export SILENT=1
+wait-for mysqladmin ping --host=$DATABASE_HOST --user=root --password=$MYSQL_ROOT_PASSWORD && \
+  log "Database connected and accessible!" || \
+  exit 1
+

--- a/bin/wait
+++ b/bin/wait
@@ -23,6 +23,7 @@ COMMAND=$@
 SLEEP=${SLEEP:-1}
 CHAR=${CHAR:-.}
 OUTPUT=${OUTPUT:-}
+TIMEOUT=${TIMEOUT:-30}
 
 if [ -z "${COMMAND}" ]; then
   echo "Usage: wait any-command-that-exits --until-successful"
@@ -57,8 +58,14 @@ log "Waiting for command to exit successfully: $COMMAND"
 
 while ! (runCommand)
 do
-   sleep $SLEEP
-   echo -n "$CHAR"
+    # Exit with an error if timeout is reached.
+    [ "$SECONDS" -gt "$TIMEOUT" ] && echo "Timeout exceeded. Command did not succeed in $SECONDS seconds." && exit 1
+
+    # Pause for $SLEEP seconds.
+    sleep $SLEEP
+
+    # Print $CHAR without a new line.
+    echo -n "$CHAR"
 done
 
 log "Done in $SECONDS seconds!"

--- a/bin/wait
+++ b/bin/wait
@@ -4,13 +4,13 @@
 #
 # @author Jon Pugh
 #
-# Runs any command over and over again until it passes.
+# Runs any command over and over again until it passes, hiding all output but printing a character every time it runs.
 #
 # Use Environment variables for options:
 #
 # SLEEP: Length of time to wait in-between running the command.
 # CHAR: The character to print after every command run.
-# OUTPUT: Set to 'err' to print all output, set to 'out' to print just stdOut. Otherwise, all output is hidden.
+# OUTPUT: Set to 'all' to print all output, set to 'out' to print just stdOut, set to "err" to print just stdErr.
 #
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/bin/wait
+++ b/bin/wait
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+##
+# wait.sh
+#
+# @author Jon Pugh
+#
+# Runs any command over and over again until it passes.
+#
+# Use Environment variables for options:
+#
+# SLEEP: Length of time to wait in-between running the command.
+# CHAR: The character to print after every command run.
+# OUTPUT: Set to 'err' to print all output, set to 'out' to print just stdOut. Otherwise, all output is hidden.
+#
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PATH="$DIR:$PATH"
+
+# All Arguments and options after `wait`
+COMMAND=$@
+
+# Environment Variables
+SLEEP=${SLEEP:-1}
+CHAR=${CHAR:-.}
+OUTPUT=${OUTPUT:-}
+
+if [ -z "${COMMAND}" ]; then
+  echo "Usage: wait any-command-that-exits --until-successful"
+  exit 1
+fi
+
+log() {
+  echo "DevShop | wait | $@";
+}
+
+runCommand() {
+
+    # If $OUTPUT=out, hide errors.
+    if [ "${OUTPUT}" == "out" ]; then
+      $COMMAND 2> /dev/null
+
+    # If $OUTPUT=err, print only errors
+    elif [ "${OUTPUT}" == "err" ]; then
+      $COMMAND > /dev/null
+
+    # If $OUTPUT=all, just print
+    elif [ "${OUTPUT}" == "all" ]; then
+      $COMMAND
+
+    # Otherwise, hide output and errors
+    else
+      $COMMAND > /dev/null 2>&1
+    fi
+}
+
+log "Waiting for command to exit successfully: $COMMAND"
+
+while ! (runCommand)
+do
+   sleep $SLEEP
+   echo -n "."
+done
+
+log "Done in $SECONDS seconds!"

--- a/bin/wait
+++ b/bin/wait
@@ -58,7 +58,7 @@ log "Waiting for command to exit successfully: $COMMAND"
 while ! (runCommand)
 do
    sleep $SLEEP
-   echo -n "."
+   echo -n "$CHAR"
 done
 
 log "Done in $SECONDS seconds!"

--- a/bin/wait-for
+++ b/bin/wait-for
@@ -11,6 +11,7 @@
 # SLEEP: Length of time to wait in-between running the command.
 # CHAR: The character to print after every command run.
 # OUTPUT: Set to 'all' to print all output, set to 'out' to print just stdOut, set to "err" to print just stdErr.
+# TIMEOUT: Default: 30. Exit with an error if process doesn't pass within this time.
 #
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -24,6 +25,7 @@ SLEEP=${SLEEP:-1}
 CHAR=${CHAR:-.}
 OUTPUT=${OUTPUT:-}
 TIMEOUT=${TIMEOUT:-30}
+SILENT=${SILENT:-""}
 
 if [ -z "${COMMAND}" ]; then
   echo "Usage: wait-for any-command-that-exits --until-successful"
@@ -54,7 +56,9 @@ runCommand() {
     fi
 }
 
-log "Waiting for command to exit successfully: $COMMAND"
+if [ -z "${SILENT}" ]; then
+    log "Waiting for command to exit successfully: $COMMAND"
+fi
 
 while ! (runCommand)
 do
@@ -68,4 +72,6 @@ do
     echo -n "$CHAR"
 done
 
-log "Done in $SECONDS seconds!"
+if [ -z "${SILENT}" ]; then
+  log "Done in $SECONDS seconds!"
+fi

--- a/bin/wait-for
+++ b/bin/wait-for
@@ -12,6 +12,7 @@
 # CHAR: The character to print after every command run.
 # OUTPUT: Set to 'all' to print all output, set to 'out' to print just stdOut, set to "err" to print just stdErr.
 # TIMEOUT: Default: 30. Exit with an error if process doesn't pass within this time.
+# SILENT: Set to 1 to not print any output except the timeout exceeded error. Useful when running from other scripts. See mysql-wait
 #
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/bin/wait-for
+++ b/bin/wait-for
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ##
-# wait.sh
+# wait-for.sh
 #
 # @author Jon Pugh
 #
@@ -26,12 +26,12 @@ OUTPUT=${OUTPUT:-}
 TIMEOUT=${TIMEOUT:-30}
 
 if [ -z "${COMMAND}" ]; then
-  echo "Usage: wait any-command-that-exits --until-successful"
+  echo "Usage: wait-for any-command-that-exits --until-successful"
   exit 1
 fi
 
 log() {
-  echo "DevShop | wait | $@";
+  echo "DevShop | wait-for | $@";
 }
 
 runCommand() {


### PR DESCRIPTION
Inspired by `mysql-wait`, and `site-wait`, we now have `wait-for`, a shell script for running a command until it passes.

Fun arguments give you control over output and timing:

```
# SLEEP: Length of time to wait in-between running the command.
# CHAR: The character to print after every command run.
# OUTPUT: Set to 'all' to print all output, set to 'out' to print just stdOut, set to "err" to print just stdErr.
# TIMEOUT: Default: 30. Exit with an error if process doesn't pass within this time.
# SILENT: Set to 1 to not print any output except the timeout exceeded error. Useful when running from other scripts. See mysql-wait
```

Try:

```
$ bin/wait-for ping google.x -c 1
DevShop | wait-for | Waiting for command to exit successfully: ping google.x -c 1
..............................Timeout exceeded. Command did not succeed in 31 seconds.
```
It will only end after the 30 second timeout.

Not sure what's happening? Set OUTPUT:

```
$ OUTPUT=err bin/wait-for ping google.x 
DevShop | wait-for | Waiting for command to exit successfully: ping google.x
ping: cannot resolve google.x: Unknown host
.ping: cannot resolve google.x: Unknown host
.ping: cannot resolve google.x: Unknown host

```

```
$ bin/wait-for ping google.com -c 4
DevShop | wait-for | Waiting for command to exit successfully: ping google.com -c 4
DevShop | wait-for | Done in 3 seconds!
```
This runs "ping" 4 times then exits successfully.
