### PR TITLE
Component / YamlTasks / Debugging failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,12 @@ jobs:
     - name: Install Composer dependencies
       run: composer install --prefer-dist --no-progress --no-suggest
 
-    # NOTE: The env vars shown below should be loaded into the Robo options automatically.
+    - name: Docker & Docker Compose Version
+      run: |
+        docker --version
+        docker-compose --version
+
+      # NOTE: The env vars shown below should be loaded into the Robo options automatically.
     # They are added to the command here for visibility.
     - name: Launch Server Container (${{ matrix.os }})
       run: |

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -427,6 +427,10 @@ class RoboFile extends \Robo\Tasks {
     // @TODO: Figure out why PowerProcess::mustRun() fails so miserably: https://github.com/opendevshop/devshop/pull/541/checks?check_run_id=518074346#step:7:45
     $process->run();
 
+    if ($process->getExitCode() != 0) {
+      throw new \Exception('Process failed: ' . $process->getExitCodeText());
+    }
+
   }
 
   /**

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -126,7 +126,7 @@ class RoboFile extends \Robo\Tasks {
   private function generateEnvironmentArgs(array $opts, $new = false) {
 
     // Convert opts to environment vars.
-    $environment = $this->generateEnvironment($opts);
+    $environment = $this->generateEnvironment($opts, $_ENV);
 
     // Load default environment, either empty or from existing.
     $return_env = $new? []: $environment;

--- a/src/DevShop/Component/PowerProcess/PowerProcess.php
+++ b/src/DevShop/Component/PowerProcess/PowerProcess.php
@@ -64,11 +64,8 @@ class PowerProcess extends BaseProcess {
      *
      * @final
      */
-    public function run($callback = null/*, array $env = []*/)
+    public function run($callback = null, array $env = [])
     {
-        // Get $env from function arguments.
-        $env = 1 < \func_num_args() ? func_get_arg(1) : null;
-
         $this->io->writeln(" <comment>$</comment> {$this->getCommandLine()} <fg=black>Output:/path/to/file</>");
 
         $timer = new TimeKeeper();

--- a/src/DevShop/Component/PowerProcess/PowerProcess.php
+++ b/src/DevShop/Component/PowerProcess/PowerProcess.php
@@ -62,10 +62,15 @@ class PowerProcess extends BaseProcess {
      * @throws RuntimeException When process stopped after receiving signal
      * @throws LogicException   In case a callback is provided and output has been disabled
      *
-     * @final
+     * @final since version 3.3
      */
-    public function run($callback = null, array $env = [])
+    public function run($callback = null, $env = [])
     {
+        // Handle a null $env variable.
+        if (!array($env)) {
+          $env = [];
+        }
+
         $this->io->writeln(" <comment>$</comment> {$this->getCommandLine()} <fg=black>Output:/path/to/file</>");
 
         $timer = new TimeKeeper();

--- a/src/DevShop/Component/PowerProcess/composer.json
+++ b/src/DevShop/Component/PowerProcess/composer.json
@@ -26,6 +26,7 @@
     },
     "extra": {
         "branch-alias": {
+            "dev-component/yaml-tasks/env-fixes": "1.6-dev",
             "dev-1.x": "1.6-dev"
         }
     },

--- a/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
+++ b/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
@@ -119,7 +119,8 @@ class YamlTasksConsoleCommand extends BaseCommand
             'github-token',
             null,
             InputOption::VALUE_REQUIRED,
-            'An active github token. Create a new token at ' . $this->addTokenUrl
+            'An active github token. Create a new token at ' . $this->addTokenUrl,
+            !empty($_SERVER['GITHUB_TOKEN'])? $_SERVER['GITHUB_TOKEN']: null
         );
         $this->addOption(
             'ignore-dirty',
@@ -190,26 +191,8 @@ class YamlTasksConsoleCommand extends BaseCommand
         // Validate YML
         $this->loadTasksYml();
 
-        // Load Environment variables
-        $dotenv = new \Dotenv\Dotenv(__DIR__);
-        $dotenv->safeLoad(array(
-
-            // Current user's home directory
-            isset($_SERVER['HOME'])? $_SERVER['HOME']: '',
-
-            // Git repo holding the tasks file.
-            dirname($this->gitRepo->getRepositoryPath()),
-
-            // Current directory
-            getcwd(),
-        ));
-
-        // Look for token.
-        if (!empty($_SERVER['GITHUB_TOKEN'])) {
-            $token = $_SERVER['GITHUB_TOKEN'];
-        } else {
-            $token = $input->getOption('github-token');
-        }
+        // Load token.
+        $token = $input->getOption('github-token');
 
         // This is the actual SHA of the working copy clone.
         $this->repoSha = $this->gitRepo->getCurrentCommit();

--- a/src/DevShop/Component/YamlTasks/composer.json
+++ b/src/DevShop/Component/YamlTasks/composer.json
@@ -21,7 +21,7 @@
         "devshop/power-process": "^1.6",
         "knplabs/github-api": "^1.4",
         "php-http/guzzle6-adapter": "^1.1",
-        "teqneers/php-stream-wrapper-for-git": "^2.0",
+        "teqneers/php-stream-wrapper-for-git": "^2.0"
     },
     "require-dev": {
         "composer/composer": "^1.10",

--- a/src/DevShop/Component/YamlTasks/composer.json
+++ b/src/DevShop/Component/YamlTasks/composer.json
@@ -29,7 +29,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-1.x": "1.6-dev"
+            "dev-1.x": "1.6-dev",
+            "dev-component/yaml-tasks/env-fixes": "1.6-dev"
         },
         "class": "DevShop\\Component\\YamlTasks\\Composer\\Plugin"
     },

--- a/src/DevShop/Component/YamlTasks/composer.json
+++ b/src/DevShop/Component/YamlTasks/composer.json
@@ -22,7 +22,6 @@
         "knplabs/github-api": "^1.4",
         "php-http/guzzle6-adapter": "^1.1",
         "teqneers/php-stream-wrapper-for-git": "^2.0",
-        "vlucas/phpdotenv": "~2"
     },
     "require-dev": {
         "composer/composer": "^1.10",

--- a/src/DevShop/Component/YamlTasks/composer.json
+++ b/src/DevShop/Component/YamlTasks/composer.json
@@ -29,8 +29,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-1.x": "1.6-dev",
-            "dev-component/yaml-tasks/env-fixes": "1.6-dev"
+            "dev-component/yaml-tasks/env-fixes": "1.6-dev",
+            "dev-1.x": "1.6-dev"
         },
         "class": "DevShop\\Component\\YamlTasks\\Composer\\Plugin"
     },


### PR DESCRIPTION
Removing dotenv loading from YamlTasks. Applications that use the **plugin** will handle their own env.

It was causing problems in https://github.com/department-of-veterans-affairs/va.gov-cms/pull/1304

No GitHub Token was found, even though the composer autoloader should be loading it from the .env file.