### PR TITLE
Component / GitHubApiCli / Add global ssl ignore option

### DIFF
--- a/devmaster/modules/devshop/devshop_github/DevShopGitHubApi.php
+++ b/devmaster/modules/devshop/devshop_github/DevShopGitHubApi.php
@@ -1,218 +1,218 @@
 <?php
-
-
-class DevShopGitHubApi {
-
-  /**
-   * @var \Github\Client
-   */
-  public $client;
-
-  /**
-   * @var stdClass
-   */
-  public $environment;
-
-  public function __construct()
-  {
-    try {
-      $this->client = devshop_github_client();
-    }
-    catch (\Exception $e) {
-      throw $e;
-    }
-  }
-
-  /**
-   * Creates a GitHub "Deployment" and "Deployment Status".
-   *
-   * If the $task does not already have a github deployment in the database,
-   * it will create a new one on GitHub. If it does, it will be loaded.
-   *
-   * Once the deployment has been loaded or created, this method sets a
-   * "GitHub Deployment Status".
-   *
-   * @see https://developer.github.com/v3/repos/deployments/#create-a-deployment
-   * @see https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
-   *
-   * @param $environment
-   *   An devshop environment object.
-   *
-   * @param $state
-   *   The state of the deployment status. Options are:
-   *   error, failure, pending, in_progress, queued, or success
-   *
-   * @param string $sha
-   *   A specific git commit SHA, if desired. If left empty, deployment will be
-   *   made against the environment "git_ref", a branch or tag.
-   * @param $log_url
-   *
-   * @return $deployment_object
-   *   A deployment object returned from GitHub.
-   */
-  static function deploy($environment, $state = 'pending', $task, $description = NULL, $sha  = NULL, $log_url = NULL) {
-
-    if (empty($task->nid)) {
-      return FALSE;
-    }
-
-    $project_node = node_load($environment->project_nid);
-    $project = $project_node->project;
-
-    $hostmaster_uri = hosting_get_hostmaster_uri();
-
-    // Lookup existing deployment for this task. I used hook_node_load() to ensure it's there, but who knows? data isn't there sometimes. Thanks, Drupal!
-    $existing_deployment_object =  unserialize(db_query('SELECT deployment_object FROM {hosting_devshop_github_deployments} WHERE task_nid = :nid', array(':nid' => $task->nid))->fetchField());
-
-    // If Deployment doesn't already exist, create it.
-    try {
-      $client = devshop_github_client();
-
-      // Git Reference. Use sha if specified.
-      $owner = $environment->github_owner;
-      $repo = $environment->github_repo;
-
-      if (!empty($environment->github_pull_request)) {
-        $ref = $environment->github_pull_request->pull_request_object->head->ref;
-        $owner = $project->github_owner;
-        $repo = $project->github_repo;
-      }
-      else {
-        $ref = $environment->git_ref;
-      }
-
-      if (empty($existing_deployment_object)) {
-        watchdog('devshop_github', 'Creating new GitHub Deployment for Task !nid', array('!nid' => $task->nid));
-        $deployment = new stdClass();
-
-        // If there is a PR, we must use the SHA in it, so that forked repos properly get deployment status.
-        if ($sha) {
-          $ref = $sha;
-        }
-
-        $deployment->ref = $ref;
-
-        // Set auto_merge based on project settings.
-        $deployment->auto_merge = (bool) $project->settings->github['pull_request_auto_merge'];
-
-        // https://developer.github.com/v3/repos/deployments/#create-a-deployment
-        $deployment->task = "deploy:{$task->task_type}";
-
-        // In GitHub's API, "environment" is just a small string it displays on the pull request:
-        // It's a better  UX to show the full URI in the "environment" field.
-        $deployment->environment = "{$environment->uri} - {$task->task_type}";
-        $deployment->payload = array(
-          'devshop_site_url' => $environment->dashboard_url,
-          'devmaster_url' => $hostmaster_uri,
-        );
-        // Deployment description is limited to
-        $deployment->description = substr(t('Deploying ref !ref to environment !env for project !proj: !link [by !server]', array(
-          '!ref' => $deployment->ref,
-          '!env' => $environment->name,
-          '!project' => $project->name,
-          '!link' => $deployment->environment,
-          '!server' => $hostmaster_uri,
-        )), 0, 140);
-        $deployment->required_contexts = array();
-
-        // @TODO: Use the developer preview to get this flag: https://developer.github.com/v3/previews/#enhanced-deployments
-  #      $deployment->transient_environment = true;
-
-        // @TODO: Support deployment notifications for production.
-  #      $deployment->production_environment = false;
-
-        // Create Deployment
-        $post_url = "/repos/$owner/$repo/deployments";
-
-        // @TODO: Detect merged branch response message and log it.
-        $deployment_object = json_decode($client->getHttpClient()->post($post_url, array(), json_encode($deployment))->getBody(TRUE));
-
-        $deployment_data = self::saveDeployment($deployment_object, $task->nid);
-        $deployment_object = $deployment_data->deployment_object;
-        watchdog('devshop_github', 'New Deployment created: ' . json_encode($deployment_object));
-
-        // @TODO: Run another git fetch! There might be new commits after the Deployment got created if there was an auto_merge.
-      }
-      // GitHub Deployment found attached to task, use that. Do not create new deployment status.
-      else {
-          $deployment_object = $existing_deployment_object;
-          watchdog('devshop_github', 'Existing Deployment loaded: ' . json_encode($deployment_object));
-      }
-    }
-    catch (Github\Exception\RuntimeException $e) {
-      watchdog('devshop_github', "GitHub Error: {$e->getMessage()} | Code: {$e->getCode()} | Post URL: $post_url");
-      // Code 409 is used when the GitHub Deployments API "Auto-merge" fails because there is a conflict.
-      // Instead of breaking our process by not getting a Deployment Object, try to save it again without auto_merge property.
-      if ((string) $e->getCode() == '409') {
-        $deployment->auto_merge = false;
-        $description .= ' ' . t('WARNING: Auto-Merge Failed. Deployed without updated primary branch.');
-
-        $deployment_object = json_decode($client->getHttpClient()->post($post_url, array(), json_encode($deployment))->getBody(TRUE));
-
-        $deployment_data = self::saveDeployment($deployment_object, $task->nid);
-        $deployment_object = $deployment_data->deployment_object;
-        watchdog('devshop_github', 'New Deployment created without auto_merge option: ' . $deployment_object->id);
-      }
-    }
-    catch (\Exception $e) {
-      watchdog('devshop_github', "GitHub Error: {$e->getMessage()} | Code: {$e->getCode()} | Post URL: $post_url | {$e->getTraceAsString()}");
-      return false;
-    }
-
-    // Deployment Status
-    $deployment_status = new stdClass();
-    $deployment_status->state = $state;
-
-    // Target URL is actually for the logs.
-    // According to GitHub API Docs:
-    // "This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. "
-    $deployment_status->log_url =
-    $deployment_status->target_url =
-      empty($log_url)? $environment->dashboard_url: $log_url;
-
-    // @TODO: Generate a default description?
-    $deployment_status->description = $description;
-
-    // @TODO: Use developer preview to get this:
-    // https://developer.github.com/v3/previews/#deployment-statuses
-    // https://developer.github.com/v3/previews/#enhanced-deployments
-    $deployment_status->environment = $deployment_object->environment;
-    $deployment_status->environment_url = $environment->url;
-
-    // Create Deployment Status
-    try {
-      $post_url = "/repos/{$owner}/{$repo}/deployments/{$deployment_object->id}/statuses";
-      $deployment_status_data = json_decode($client->getHttpClient()->post($post_url, array(), json_encode($deployment_status))->getBody(TRUE));
-
-      watchdog('devshop_github', "Deployment status saved to $state: $deployment_status_data->id");
-      return $deployment_object;
-    }
-    catch (\Exception $e) {
-      watchdog('devshop_github', "Error sending Deployment Status to GitHub: {$e->getMessage()} | Code: {$e->getCode()} | Post URL: $post_url | {$e->getTraceAsString()}");
-      return false;
-    }
-  }
-
-  /**
-   * Save Deployment. Deployments never get updated.
-   *
-   * @param $project_nid
-   * @param $environment_name
-   * @param $deployment_id
-   */
-  public static function saveDeployment($deployment, $task_nid)  {
-
-    if (empty($task_nid)) {
-      return false;
-    }
-    $record = new stdClass();
-    $record->deployment_id = $deployment->id;
-    $record->task_nid = $task_nid;
-    $record->deployment_object = serialize($deployment);
-    drupal_write_record('hosting_devshop_github_deployments', $record);
-
-    // Unserialize and return.
-    $record->deployment_object = $deployment;
-    return $record;
-  }
-}
+//
+//
+//class DevShopGitHubApi {
+//
+//  /**
+//   * @var \Github\Client
+//   */
+//  public $client;
+//
+//  /**
+//   * @var stdClass
+//   */
+//  public $environment;
+//
+//  public function __construct()
+//  {
+//    try {
+//      $this->client = devshop_github_client();
+//    }
+//    catch (\Exception $e) {
+//      throw $e;
+//    }
+//  }
+//
+//  /**
+//   * Creates a GitHub "Deployment" and "Deployment Status".
+//   *
+//   * If the $task does not already have a github deployment in the database,
+//   * it will create a new one on GitHub. If it does, it will be loaded.
+//   *
+//   * Once the deployment has been loaded or created, this method sets a
+//   * "GitHub Deployment Status".
+//   *
+//   * @see https://developer.github.com/v3/repos/deployments/#create-a-deployment
+//   * @see https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+//   *
+//   * @param $environment
+//   *   An devshop environment object.
+//   *
+//   * @param $state
+//   *   The state of the deployment status. Options are:
+//   *   error, failure, pending, in_progress, queued, or success
+//   *
+//   * @param string $sha
+//   *   A specific git commit SHA, if desired. If left empty, deployment will be
+//   *   made against the environment "git_ref", a branch or tag.
+//   * @param $log_url
+//   *
+//   * @return $deployment_object
+//   *   A deployment object returned from GitHub.
+//   */
+//  static function deploy($environment, $state = 'pending', $task, $description = NULL, $sha  = NULL, $log_url = NULL) {
+//
+//    if (empty($task->nid)) {
+//      return FALSE;
+//    }
+//
+//    $project_node = node_load($environment->project_nid);
+//    $project = $project_node->project;
+//
+//    $hostmaster_uri = hosting_get_hostmaster_uri();
+//
+//    // Lookup existing deployment for this task. I used hook_node_load() to ensure it's there, but who knows? data isn't there sometimes. Thanks, Drupal!
+//    $existing_deployment_object =  unserialize(db_query('SELECT deployment_object FROM {hosting_devshop_github_deployments} WHERE task_nid = :nid', array(':nid' => $task->nid))->fetchField());
+//
+//    // If Deployment doesn't already exist, create it.
+//    try {
+//      $client = devshop_github_client();
+//
+//      // Git Reference. Use sha if specified.
+//      $owner = $environment->github_owner;
+//      $repo = $environment->github_repo;
+//
+//      if (!empty($environment->github_pull_request)) {
+//        $ref = $environment->github_pull_request->pull_request_object->head->ref;
+//        $owner = $project->github_owner;
+//        $repo = $project->github_repo;
+//      }
+//      else {
+//        $ref = $environment->git_ref;
+//      }
+//
+//      if (empty($existing_deployment_object)) {
+//        watchdog('devshop_github', 'Creating new GitHub Deployment for Task !nid', array('!nid' => $task->nid));
+//        $deployment = new stdClass();
+//
+//        // If there is a PR, we must use the SHA in it, so that forked repos properly get deployment status.
+//        if ($sha) {
+//          $ref = $sha;
+//        }
+//
+//        $deployment->ref = $ref;
+//
+//        // Set auto_merge based on project settings.
+//        $deployment->auto_merge = (bool) $project->settings->github['pull_request_auto_merge'];
+//
+//        // https://developer.github.com/v3/repos/deployments/#create-a-deployment
+//        $deployment->task = "deploy:{$task->task_type}";
+//
+//        // In GitHub's API, "environment" is just a small string it displays on the pull request:
+//        // It's a better  UX to show the full URI in the "environment" field.
+//        $deployment->environment = "{$environment->uri} - {$task->task_type}";
+//        $deployment->payload = array(
+//          'devshop_site_url' => $environment->dashboard_url,
+//          'devmaster_url' => $hostmaster_uri,
+//        );
+//        // Deployment description is limited to
+//        $deployment->description = substr(t('Deploying ref !ref to environment !env for project !proj: !link [by !server]', array(
+//          '!ref' => $deployment->ref,
+//          '!env' => $environment->name,
+//          '!project' => $project->name,
+//          '!link' => $deployment->environment,
+//          '!server' => $hostmaster_uri,
+//        )), 0, 140);
+//        $deployment->required_contexts = array();
+//
+//        // @TODO: Use the developer preview to get this flag: https://developer.github.com/v3/previews/#enhanced-deployments
+//  #      $deployment->transient_environment = true;
+//
+//        // @TODO: Support deployment notifications for production.
+//  #      $deployment->production_environment = false;
+//
+//        // Create Deployment
+//        $post_url = "/repos/$owner/$repo/deployments";
+//
+//        // @TODO: Detect merged branch response message and log it.
+//        $deployment_object = json_decode($client->getHttpClient()->post($post_url, array(), json_encode($deployment))->getBody(TRUE));
+//
+//        $deployment_data = self::saveDeployment($deployment_object, $task->nid);
+//        $deployment_object = $deployment_data->deployment_object;
+//        watchdog('devshop_github', 'New Deployment created: ' . json_encode($deployment_object));
+//
+//        // @TODO: Run another git fetch! There might be new commits after the Deployment got created if there was an auto_merge.
+//      }
+//      // GitHub Deployment found attached to task, use that. Do not create new deployment status.
+//      else {
+//          $deployment_object = $existing_deployment_object;
+//          watchdog('devshop_github', 'Existing Deployment loaded: ' . json_encode($deployment_object));
+//      }
+//    }
+//    catch (Github\Exception\RuntimeException $e) {
+//      watchdog('devshop_github', "GitHub Error: {$e->getMessage()} | Code: {$e->getCode()} | Post URL: $post_url");
+//      // Code 409 is used when the GitHub Deployments API "Auto-merge" fails because there is a conflict.
+//      // Instead of breaking our process by not getting a Deployment Object, try to save it again without auto_merge property.
+//      if ((string) $e->getCode() == '409') {
+//        $deployment->auto_merge = false;
+//        $description .= ' ' . t('WARNING: Auto-Merge Failed. Deployed without updated primary branch.');
+//
+//        $deployment_object = json_decode($client->getHttpClient()->post($post_url, array(), json_encode($deployment))->getBody(TRUE));
+//
+//        $deployment_data = self::saveDeployment($deployment_object, $task->nid);
+//        $deployment_object = $deployment_data->deployment_object;
+//        watchdog('devshop_github', 'New Deployment created without auto_merge option: ' . $deployment_object->id);
+//      }
+//    }
+//    catch (\Exception $e) {
+//      watchdog('devshop_github', "GitHub Error: {$e->getMessage()} | Code: {$e->getCode()} | Post URL: $post_url | {$e->getTraceAsString()}");
+//      return false;
+//    }
+//
+//    // Deployment Status
+//    $deployment_status = new stdClass();
+//    $deployment_status->state = $state;
+//
+//    // Target URL is actually for the logs.
+//    // According to GitHub API Docs:
+//    // "This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. "
+//    $deployment_status->log_url =
+//    $deployment_status->target_url =
+//      empty($log_url)? $environment->dashboard_url: $log_url;
+//
+//    // @TODO: Generate a default description?
+//    $deployment_status->description = $description;
+//
+//    // @TODO: Use developer preview to get this:
+//    // https://developer.github.com/v3/previews/#deployment-statuses
+//    // https://developer.github.com/v3/previews/#enhanced-deployments
+//    $deployment_status->environment = $deployment_object->environment;
+//    $deployment_status->environment_url = $environment->url;
+//
+//    // Create Deployment Status
+//    try {
+//      $post_url = "/repos/{$owner}/{$repo}/deployments/{$deployment_object->id}/statuses";
+//      $deployment_status_data = json_decode($client->getHttpClient()->post($post_url, array(), json_encode($deployment_status))->getBody(TRUE));
+//
+//      watchdog('devshop_github', "Deployment status saved to $state: $deployment_status_data->id");
+//      return $deployment_object;
+//    }
+//    catch (\Exception $e) {
+//      watchdog('devshop_github', "Error sending Deployment Status to GitHub: {$e->getMessage()} | Code: {$e->getCode()} | Post URL: $post_url | {$e->getTraceAsString()}");
+//      return false;
+//    }
+//  }
+//
+//  /**
+//   * Save Deployment. Deployments never get updated.
+//   *
+//   * @param $project_nid
+//   * @param $environment_name
+//   * @param $deployment_id
+//   */
+//  public static function saveDeployment($deployment, $task_nid)  {
+//
+//    if (empty($task_nid)) {
+//      return false;
+//    }
+//    $record = new stdClass();
+//    $record->deployment_id = $deployment->id;
+//    $record->task_nid = $task_nid;
+//    $record->deployment_object = serialize($deployment);
+//    drupal_write_record('hosting_devshop_github_deployments', $record);
+//
+//    // Unserialize and return.
+//    $record->deployment_object = $deployment;
+//    return $record;
+//  }
+//}

--- a/devmaster/modules/devshop/devshop_github/devshop_github.drush.inc
+++ b/devmaster/modules/devshop/devshop_github/devshop_github.drush.inc
@@ -156,12 +156,12 @@ function devshop_github_hosting_task_update_status($task, $status) {
     $state = 'failure';
   }
 
-  // The method ::deploy() should return the existing deployment object for the $task_reloaded.
-  $deployment_object = DevShopGitHubApi::deploy($environment, $state, $task_reloaded, $description, $sha, $task_url);
-
-  if (!$deployment_object){
-    drush_log("@TODO: Unable to set new deployment status: $deployment_object Empty: [$task->nid] $state", 'warning');
-  }
+//  // The method ::deploy() should return the existing deployment object for the $task_reloaded.
+//  $deployment_object = DevShopGitHubApi::deploy($environment, $state, $task_reloaded, $description, $sha, $task_url);
+//
+//  if (!$deployment_object){
+//    drush_log("@TODO: Unable to set new deployment status: $deployment_object Empty: [$task->nid] $state", 'warning');
+//  }
 //
 //  // React only on certain task types and if project and environment exist.
 //  $types = array('install', 'test', 'devshop-deploy');

--- a/devmaster/modules/devshop/devshop_github/devshop_github.install
+++ b/devmaster/modules/devshop/devshop_github/devshop_github.install
@@ -39,33 +39,6 @@ function devshop_github_schema() {
     ),
     'primary key' => array('site_nid'),
   );
-  $schema['hosting_devshop_github_deployments'] = array(
-    'fields' => array(
-      'task_nid' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'default' => 0,
-        'description' => "The Task Node NID associated with the deployment.",
-      ),
-      'deployment_id' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'default' => 0,
-        'description' => 'GitHub Deployment ID',
-      ),
-      'deployment_object' => array(
-        'type' => 'text',
-        'not null' => FALSE,
-        'size' => 'big',
-        'description' => 'A serialized array of settings for this environment.',
-      ),
-    ),
-    'primary key' => array(
-        'task_nid'
-    ),
-  );
   return $schema;
 }
 
@@ -160,4 +133,11 @@ function devshop_github_update_7004() {
 
   // 3. Delete old project_nid and env name fields.
 
+}
+
+/**
+ * Delete the hosting_devshop_github_deployments table.
+ */
+function devshop_github_update_7004() {
+  db_query('DROP TABLE {hosting_devshop_github_deployments}');
 }

--- a/devmaster/modules/devshop/devshop_github/devshop_github.install
+++ b/devmaster/modules/devshop/devshop_github/devshop_github.install
@@ -138,6 +138,6 @@ function devshop_github_update_7004() {
 /**
  * Delete the hosting_devshop_github_deployments table.
  */
-function devshop_github_update_7004() {
+function devshop_github_update_7005() {
   db_query('DROP TABLE {hosting_devshop_github_deployments}');
 }

--- a/devmaster/modules/devshop/devshop_github/devshop_github.module
+++ b/devmaster/modules/devshop/devshop_github/devshop_github.module
@@ -1099,15 +1099,6 @@ function devshop_github_project_create_webhook($form, $form_state) {
  */
 function devshop_github_node_load($nodes, $types) {
 
-  // Load each tasks deployment object.
-  $types_we_want_to_process = array('task');
-  if (count(array_intersect($types_we_want_to_process, $types))) {
-    $result = db_query('SELECT * FROM {hosting_devshop_github_deployments} WHERE task_nid IN(:nids)', array(':nids' => array_keys($nodes)));
-    foreach ($result as $record) {
-      $nodes[$record->task_nid]->github_deployment = unserialize($record->deployment_object);
-    }
-  }
-
   foreach ($nodes as $nid => &$node) {
     if ($node->type == 'project') {
       // Look for a pull request object.
@@ -1138,21 +1129,6 @@ function devshop_github_node_insert($node) {
     $environment->name = $node->environment_name;
     $environment->project_nid = $node->project_nid;
     devshop_github_save_pr_env_data($node->pull_request, $environment);
-  }
-
-  if ($node->type == 'task' && $node->task_type == 'devshop-deploy') {
-
-    // Get the latest environment info.
-    $site = node_load($node->rid, null, true);
-    if ($site->type == 'site' && isset($site->environment)) {
-      // Create a deployment on GitHub.
-      $deployment = DevShopGitHubApi::deploy($site->environment, 'pending', $node, t('DevShop Deploy task queued.'), NULL, url("node/$node->nid", array(
-        'absolute' => true,
-      )));
-      watchdog('devshop_github', t('DevShop Deploy Task created [%nid] and GitHub Deployment Created: [%id]'), array(
-        '%id' => $deployment->id,
-      ));
-    }
   }
 }
 

--- a/src/DevShop/Component/GitHubApiCli/GitHubApiCli.php
+++ b/src/DevShop/Component/GitHubApiCli/GitHubApiCli.php
@@ -11,7 +11,7 @@ class GitHubApiCli
   /**
    * @var GitHubApiClient
    */
-  private $apiClient;
+  public $apiClient;
 
   /**
    * GitHubApiCli constructor
@@ -32,6 +32,11 @@ class GitHubApiCli
     $this->apiClient = new GitHubApiClient();
     // @TODO: Allow password auth?
     $this->apiClient->authenticate($this->getToken(), null, GitHubApiClient::AUTH_HTTP_TOKEN);
+
+    // Skip SSL verification if ENV var is found.
+    if (getenv('DEVSHOP_GITHUB_API_IGNORE_SSL')) {
+      $this->apiClient->getHttpClient()->client->setDefaultOption('verify', false);
+    }
 
     // Set options or headers from CLI or config options.
     // @see Client::options

--- a/src/DevShop/Component/GitHubApiCli/README.md
+++ b/src/DevShop/Component/GitHubApiCli/README.md
@@ -120,6 +120,22 @@ Show info about a repo:
   html_url            https://github.com/department-of-veterans-affairs/va.gov-cms                                                     
 ```
 
+## SSL Issues
+
+If you encounter any SSL errors, such as the one below, you can tell the 
+HTTPClient Library Guzzle to skip SSL verification.
+
+    60: SSL certificate problem: self signed certificate in certificate chain
+    
+All DevShop components that use the GitHub API can be configured to skip the SSL
+certificate verification. Set the following environment variable to ignore SSL 
+errors:
+
+    export DEVSHOP_GITHUB_API_IGNORE_SSL=1
+
+See [YamlTasksConsoleCommand.php](https://github.com/opendevshop/devshop/blob/1.x/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php#L271) and [GitHubApiCli.php](https://github.com/opendevshop/devshop/blob/1.x/src/DevShop/Component/GitHubApiCli/GitHubApiCli.php) to see the 
+implementation.
+
 Resources
 ---------
 

--- a/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
+++ b/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
@@ -267,7 +267,7 @@ class YamlTasksConsoleCommand extends BaseCommand
         if (!$input->getOption('dry-run')) {
             $this->githubClient = new \Github\Client();
 
-            if ($input->getOption('ignore-ssl')) {
+            if ($input->getOption('ignore-ssl') || getenv('DEVSHOP_GITHUB_API_IGNORE_SSL')) {
                 $this->githubClient->getHttpClient()->client->setDefaultOption('verify', false);
             }
 


### PR DESCRIPTION
Local custom certs cause problems. CURL fails, which means HTTPClient / Guzzle fails.

In YamlTasks we added `--ignore-ssl` CLI option, but the API usage is so broad, we should have a global way to turn off "verify".

This PR adds an environment variable that can be checked on all implementations of the GitHub Client.php class.

