### PR TITLE
CI / Scheduled Builds / 1.x Builds failing because of bad `github deployment` call.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
-  GITHUB_RUN_LOG_URL: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true
+  GITHUB_RUN_LOG_URL: https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}?check_suite_focus=true
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,7 @@ name: Build
 
 on:
  push:
-   branches:
-   - 1.x
+   branches: 1.x
  pull_request:
    types: [opened, synchronize]
  schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,12 +77,12 @@ jobs:
     - name: Create a GitHub Deployment to PR environment
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        bin/github deployment:start --environment=github.${OS}.pr${GITHUB_PR_NUMBER} --ref=${GITHUB_PR_SHA} --description="Triggered from ./.github/workflows/build.yml"
+        bin/github deployment:start --environment=github.pr${GITHUB_PR_NUMBER}.${OS} --ref=${GITHUB_PR_SHA} --description="Triggered from ./.github/workflows/build.yml"
 
     - name: Create a GitHub Deployment to branch environment
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        bin/github deployment:start --environment=github.${OS}.$(bin/branch-or-tag) --ref=${GITHUB_SHA}  --description="Triggered from ./.github/workflows/build.yml"
+        bin/github deployment:start --environment=github.$(bin/branch-or-tag).${OS} --ref=${GITHUB_SHA}  --description="Triggered from ./.github/workflows/build.yml"
 
     - name: Docker & Docker Compose Version
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
-  GITHUB_RUN_LOG_URL: https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}?check_suite_focus=true
 
 jobs:
   build:
@@ -47,6 +46,7 @@ jobs:
       ANSIBLE_VARS: "${{ matrix.vars }}"
       DEVSHOP_SERVER_HOSTNAME: "${{ matrix.os }}.actions.github.com"
       OS: "${{ matrix.os }}"
+      GITHUB_RUN_LOG_URL: https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}?check_suite_focus=true
 
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
-  GITHUB_RUN_LOG_URL: https://github.com/opendevshop/devshop/runs/${{ github.run_id }}
+  GITHUB_RUN_LOG_URL: https://github.com/opendevshop/devshop/actions/runs/${{ github.run_id }}
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
+  GITHUB_RUN_LOG_URL: ${{ github.event.pull_request._links.html }}
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
       ANSIBLE_VARS: "${{ matrix.vars }}"
       DEVSHOP_SERVER_HOSTNAME: "${{ matrix.os }}.actions.github.com"
       OS: "${{ matrix.os }}"
-      GITHUB_RUN_LOG_URL: https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}?check_suite_focus=true
 
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
-  GITHUB_RUN_LOG_URL: ${{ github.event.pull_request._links.html }}
+  GITHUB_RUN_LOG_URL: https://github.com/opendevshop/devshop/runs/${{ github.run_id }}
 
 jobs:
   build:

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -14,7 +14,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
-  GITHUB_RUN_LOG_URL: https://github.com/opendevshop/devshop/runs/${{ github.run_id }}
+  GITHUB_RUN_LOG_URL: https://github.com/opendevshop/devshop/actions/runs/${{ github.run_id }}
 
 jobs:
   yaml-tasks:

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -12,6 +12,9 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
+  GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+  GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
+  GITHUB_RUN_LOG_URL: https://github.com/opendevshop/devshop/runs/${{ github.run_id }}
 
 jobs:
   yaml-tasks:
@@ -52,20 +55,16 @@ jobs:
         composer require devshop/power-process
         composer install --prefer-dist --no-progress --no-suggest
 
-    - name: Run Yaml Tests
+    - name: Run Yaml Tasks
       working-directory: ${{env.working-directory}}
       env:
-        GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
-        GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
-        GITHUB_RUN_LOG_URL: https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}?check_suite_focus=true
-
         # @TODO: Get environment variable setting to work.
         # YAML_TASKS_STATUS_URL: https://github.com/${GITHUB_REPOSITORY}/runs/${GITHUB_RUN_ID}?check_suite_focus=true
         PROVISION_PROCESS_OUTPUT: direct
       run: |
         chmod +x yaml-tasks
-        ./yaml-tasks  --ansi -v --hostname=github.com --status-url=${GITHUB_RUN_LOG_URL}
-        ./yaml-tasks --tasks-file tests.yml --ansi -v --hostname=github.com --status-url=${GITHUB_RUN_LOG_URL}
+        ./yaml-tasks  --ansi -v --hostname=github.com --status-url=${GITHUB_RUN_LOG_URL}#step:7:1
+        ./yaml-tasks --tasks-file tests.yml --ansi -v --hostname=github.com --status-url=${GITHUB_RUN_LOG_URL}#step:7:1
 
   power-process:
     name: PowerProcess

--- a/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
+++ b/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
@@ -450,7 +450,6 @@ class YamlTasksConsoleCommand extends BaseCommand
                             "Successful in {$process->duration} on {$input->getOption('hostname')}",
                         )
                     );
-
                 } else {
                     // If the task has the ignore failure flag, ignore it.
                     if (!empty($task['ignore-failure'])) {

--- a/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
+++ b/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
@@ -544,6 +544,11 @@ BODY;
 
                                 $this->successLite("Comment Created: {$comment_response['html_url']}");
 
+                                // GitHub Actions, we want to test posting a comment but we don't want to see the comment.
+                                if (getenv('GITHUB_ACTIONS')) {
+                                    $client->repos()->comments()->remove($this->repoOwner, $this->repoName, $comment_response['id']);
+                                }
+
                                 // @TODO: Set Target URL from yaml-task options.
                                 // $params->target_url = $this->getTargetUrl($comment_response['html_url']);
                                 // Always use the main target url... If this is overridable, it should be configurable by the user in their tasks,yml.

--- a/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
+++ b/src/DevShop/Component/YamlTasks/Command/YamlTasksConsoleCommand.php
@@ -364,7 +364,9 @@ class YamlTasksConsoleCommand extends BaseCommand
                     );
                     $params->context = $task_name;
 
-                    $params->description = substr($params->description, 0, self::GITHUB_STATUS_DESCRIPTION_MAX_SIZE - 3) . '...';
+                    if (strlen($params->description) > self::GITHUB_STATUS_DESCRIPTION_MAX_SIZE) {
+                        $params->description = substr($params->description, 0, self::GITHUB_STATUS_DESCRIPTION_MAX_SIZE - 1) . '…';
+                    }
 
                     // Post status to github
                     try {
@@ -559,7 +561,7 @@ BODY;
                 }
 
                 if (!$input->getOption('dry-run')) {
-                    $params->description = substr($params->description, 0, self::GITHUB_STATUS_DESCRIPTION_MAX_SIZE - 3) . '...';
+                    $params->description = substr($params->description, 0, self::GITHUB_STATUS_DESCRIPTION_MAX_SIZE);
                     $response = $client->getHttpClient()->post("/repos/$this->repoOwner/$this->repoName/statuses/$this->repoSha", json_encode($params));
                     $this->commitStatusMessage($response, $task_name, $task, $params->state);
                 }


### PR DESCRIPTION
The environment variable doesn't exist in scheduled 1.x github action runs.

Use --ref=sha to force the deployment to use the current clone SHA.