### PR TITLE
Detect hostname from `hostname -f` if `server_hostname` variable is not explicitly set.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     ports:
       - "80:80"
       - "2222:22"
-    hostname: devshop.local.computer
+    hostname: docker.devshop.local.computer
     extra_hosts:
       - "drpl8.testenv.devshop.local.computer:127.0.0.1"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     ports:
       - "80:80"
       - "2222:22"
-    hostname: docker.devshop.local.computer
+    hostname: devshop.local.computer
     extra_hosts:
       - "drpl8.testenv.devshop.local.computer:127.0.0.1"
     environment:

--- a/install/install.sh
+++ b/install/install.sh
@@ -526,7 +526,8 @@ fi
 # Strangest thing: if you leave a space after the variable "name:" the output will convert to a new line.
 IFS=$'\n'
 ANSIBLE_EXTRA_VARS=()
-ANSIBLE_EXTRA_VARS+=("server_hostname: ${HOSTNAME_FQDN}")
+# @TODO: Remove once we know #627 is passing: Ansible roles now detect the hostname.
+# ANSIBLE_EXTRA_VARS+=("server_hostname: ${HOSTNAME_FQDN}")
 ANSIBLE_EXTRA_VARS+=("devshop_cli_path: ${DEVSHOP_INSTALL_PATH}")
 ANSIBLE_EXTRA_VARS+=("playbook_path: ${DEVSHOP_INSTALL_PATH}")
 ANSIBLE_EXTRA_VARS+=("aegir_server_webserver: ${SERVER_WEBSERVER}")

--- a/roles/devshop.server/play.yml
+++ b/roles/devshop.server/play.yml
@@ -8,10 +8,6 @@
   become: true
 
   vars:
-    # Hostname must be set when container is launched, which "hostname" option.
-    server_hostname: "devshop.local.computer"
-    server_hostname_ignore_errors: true
-
     # The geerlingguy.mysql and opendevshop.devmaster roles both use this
     mysql_root_password: root
 

--- a/roles/docker-compose.yml
+++ b/roles/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "drpl8.testenv.devshop.local.computer:127.0.0.1"
     # @TODO: Change back to devshop.local.computer
     # Windows WSL2 Docker was not allowing me to load by devshop.local.computer. This is a workaround.
-    hostname: localhost
+    hostname: devshop.local.computer
     ports:
       - "80:80"
       - "2222:22"

--- a/roles/opendevshop.devmaster/defaults/main.yml
+++ b/roles/opendevshop.devmaster/defaults/main.yml
@@ -2,7 +2,8 @@
 
 # Server hostname will default to this unless overridden in your inventory or extra_vars.
 # It is overridden in devshop's install.sh file to match the server's current hostname.
-server_hostname: devshop.local.computer
+# server_hostname: devshop.local.computer
+
 server_hostname_ignore_errors: true
 devshop_devmaster_email: admin@devshop.local.computer
 

--- a/roles/opendevshop.devmaster/defaults/main.yml
+++ b/roles/opendevshop.devmaster/defaults/main.yml
@@ -66,8 +66,9 @@ devshop_control_install_options: ""
 
 devshop_install_profile: devmaster
 
+# The command used to install the control site.
+# Do not pass --site, it will be detected from the server's current hostname.
 devmaster_install_command: "{{ devshop_cli_bin_path }}/devshop devmaster:install -n \
-                                --site={{ server_hostname }} \
                                 --aegir_db_host={{ database_host }} \
                                 --aegir_db_pass={{ mysql_root_password }} \
                                 --aegir_db_user={{ mysql_root_username }} \

--- a/roles/opendevshop.devmaster/tasks/main.yml
+++ b/roles/opendevshop.devmaster/tasks/main.yml
@@ -7,12 +7,6 @@
   become: false
   tags: [runtime]
 
-- name: Define server_hostname using 'hostname -f' command.
-  set_fact:
-    server_hostname: "{{ _server_hostname_fqdn_command.stdout }}"
-  when: server_hostname is not defined
-  tags: [runtime]
-
 - name: Set default server_hostname at buildtime only.
   set_fact:
     server_hostname: "{{ default_server_hostname }}"
@@ -20,10 +14,16 @@
     - ('runtime' not in ansible_run_tags)
     - server_hostname is not defined
 
+- name: Define server_hostname using 'hostname -f' command.
+  set_fact:
+    server_hostname: "{{ _server_hostname_fqdn_command.stdout }}"
+  when: server_hostname is not defined
+  tags: [runtime]
+
 - name: Display server_hostname.
   debug:
     msg: "{{ server_hostname }}"
-  tags: [runtime]
+  tags: [always]
 
 - name: Set Server Hostname
   hostname:

--- a/roles/opendevshop.devmaster/tasks/main.yml
+++ b/roles/opendevshop.devmaster/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: Detect current server hostname.
-  command: "hostname -f"
+  command: "hostname --fqdn"
   register: _server_hostname_fqdn_command
   failed_when: "_server_hostname_fqdn_command.stdout is undefined"
   become: false
   tags: [always]
 
-- name: Set server_hostname from server hostname.
+- name: Set server_hostname from current server hostname.
   set_fact:
     server_hostname: "{{ _server_hostname_fqdn_command.stdout }}"
   when: server_hostname is not defined

--- a/roles/opendevshop.devmaster/tasks/main.yml
+++ b/roles/opendevshop.devmaster/tasks/main.yml
@@ -1,4 +1,30 @@
 ---
+
+- name: Detect current server hostname.
+  command: "hostname -f"
+  register: _server_hostname_fqdn_command
+  failed_when: "_server_hostname_fqdn_command.stdout is undefined"
+  become: false
+  tags: [runtime]
+
+- name: Define server_hostname using 'hostname -f' command.
+  set_fact:
+    server_hostname: "{{ _server_hostname_fqdn_command.stdout }}"
+  when: server_hostname is not defined
+  tags: [runtime]
+
+- name: Set default server_hostname at buildtime only.
+  set_fact:
+    server_hostname: "{{ default_server_hostname }}"
+  when:
+    - ('runtime' not in ansible_run_tags)
+    - server_hostname is not defined
+
+- name: Display server_hostname.
+  debug:
+    msg: "{{ server_hostname }}"
+  tags: [runtime]
+
 - name: Set Server Hostname
   hostname:
     name: "{{ server_hostname }}"

--- a/roles/opendevshop.devmaster/tasks/main.yml
+++ b/roles/opendevshop.devmaster/tasks/main.yml
@@ -5,20 +5,13 @@
   register: _server_hostname_fqdn_command
   failed_when: "_server_hostname_fqdn_command.stdout is undefined"
   become: false
-  tags: [runtime]
+  tags: [always]
 
-- name: Set default server_hostname at buildtime only.
-  set_fact:
-    server_hostname: "{{ default_server_hostname }}"
-  when:
-    - ('runtime' not in ansible_run_tags)
-    - server_hostname is not defined
-
-- name: Define server_hostname using 'hostname -f' command.
+- name: Set server_hostname from server hostname.
   set_fact:
     server_hostname: "{{ _server_hostname_fqdn_command.stdout }}"
   when: server_hostname is not defined
-  tags: [runtime]
+  tags: [always]
 
 - name: Display server_hostname.
   debug:

--- a/roles/opendevshop.devmaster/tasks/main.yml
+++ b/roles/opendevshop.devmaster/tasks/main.yml
@@ -7,7 +7,7 @@
   become: false
   tags: [always]
 
-- name: Set server_hostname from current server hostname.
+- name: Set server_hostname variable from current server hostname.
   set_fact:
     server_hostname: "{{ _server_hostname_fqdn_command.stdout }}"
   when: server_hostname is not defined

--- a/roles/opendevshop.devmaster/vars/main.yml
+++ b/roles/opendevshop.devmaster/vars/main.yml
@@ -1,4 +1,9 @@
 ---
+
+# Default server hostname. Will be set if `server_hostname` var is not set.
+# Used in Docker build or image build process
+default_server_hostname: devshop.local.computer
+
 empty_string: ""
 
 # Add hosting-queue-runner to supervisor programs.

--- a/src/DevShop/Command/InstallDevmaster.php
+++ b/src/DevShop/Command/InstallDevmaster.php
@@ -412,9 +412,10 @@ class InstallDevmaster extends Command
   /**
    * return the FQDN of the machine or provided host
    *
-   * this replicates hostname -f, which is not portable
+   * this replicates hostname -f, which is not portable across OS.
    *
    * Copy of provision_fqdn()
+   * @TODO: We rely on `hostname --fqdn` in other places. Shouldn't we use it consistently?
    */
   private function findFqdn($host = NULL) {
     if (is_null($host)) {


### PR DESCRIPTION
1. Docker containers always run devshop.local.computer unless ANSIBLE_EXTRA_VARS has `server_hostname` set.
2. New cloud servers that already have hostnames set should pass that automatically to the installer without needing to explicitly set `server_hostname`