### PR TITLE
DevShop Control not installing correctly because of composer version.

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -9,6 +9,7 @@ on:
   schedule:
     # Once per day. https://crontab.guru/#*_0_*_*_*
     - cron: "* 0 * * *"
+    - cron: "0 12 * * *"
 
 env:
   GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -270,7 +270,7 @@ jobs:
 
       # If installing without a lockfile, composer suggests using "update" command instead.
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress
+        run: composer reinstall
         working-directory: ${{env.working-directory}}
 
       - name: Test Project Creation

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -279,3 +279,5 @@ jobs:
         working-directory: ./src/DevShop/Component/
         run: |
           composer create-project devshop/control-template:@dev temp --repository='{"type":"path","url":"DevShopControlTemplate"}'
+
+        # @TODO: Launch a devshop test container around this devshop-control code.

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -5,7 +5,7 @@ on:
     branches: 1.x
   pull_request:
     types: [opened, synchronize]
-
+  workflow_dispatch:
   schedule:
     # Once per day. https://crontab.guru/#*_0_*_*_*
     - cron: "* 0 * * *"

--- a/.github/workflows/devshop-container-prep.sh
+++ b/.github/workflows/devshop-container-prep.sh
@@ -5,6 +5,9 @@ PATH="$DEVSHOP_PATH/bin:$PATH"
 GIT_REF=${GITHUB_HEAD_REF:-"1.x"}
 
 devshop-logo "Preparing DevShop Control for CI Tests"
+devshop-log "Creating local branch from the checked out commit with the expected name..."
+cd "$DEVSHOP_PATH"
+git checkout -b $GIT_REF
 
 devshop-log "Adding repos to composer global config."
 set -x

--- a/.github/workflows/devshop-container-prep.sh
+++ b/.github/workflows/devshop-container-prep.sh
@@ -6,6 +6,14 @@ GIT_REF=${GITHUB_HEAD_REF:-"1.x"}
 
 devshop-logo "Preparing DevShop Control for CI Tests"
 devshop-log "Creating local branch from the checked out commit with the expected name..."
+
+# Create a local branch in the "path" repo so that composer doesn't get all confused. When the path is a SHA, composer reads the version as `devshop/devmaster[dev-8207dc45845c7cc0e4e8271d9c097fcb108a5773]`
+# Assumption: Having a local branch will make composer detect the devshop/devmaster repo as being at version `devshop/devmaster[1.x-dev]`.
+# I discovered this is happening by noticing that local composer install fails had a different error message:
+# In GitHub Actions: https://github.com/opendevshop/devshop/pull/629/checks?check_run_id=1392567826#step:4:227
+#   - Root composer.json requires devshop/devmaster ^1.7@alpha||1.x-dev, it is satisfiable by devshop/devmaster[1.7.0-alpha1, 1.7.0-alpha2, 1.7.0-alpha3, 1.x-dev] from composer repo (https://repo.packagist.org) but devshop/devmaster[dev-8207dc45845c7cc0e4e8271d9c097fcb108a5773] from path repo (/usr/share/devshop/devmaster) has higher repository priority.
+# Locally, it says `devshop/devmaster[1.x-dev]` instead, because my local path repo is on a branch.
+
 cd "$DEVSHOP_PATH"
 git checkout -b $GIT_REF
 

--- a/.github/workflows/devshop-container-prep.sh
+++ b/.github/workflows/devshop-container-prep.sh
@@ -15,7 +15,7 @@ devshop-log "Creating local branch from the checked out commit with the expected
 # Locally, it says `devshop/devmaster[1.x-dev]` instead, because my local path repo is on a branch.
 
 cd "$DEVSHOP_PATH"
-git checkout -b $GIT_REF
+git checkout -b 1.x
 
 devshop-log "Adding repos to composer global config."
 set -x

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -38,7 +38,7 @@
         "drupal-composer/preserve-paths": "dev-composer2",
         "drupal/admin_menu": "@rc",
         "drupal/adminrole": "^1.1",
-         "drupal/aegir_config": "@beta",
+        "drupal/aegir_config": "@beta",
         "drupal/aegir_ssh": "^1.0",
         "drupal/betterlogin": "^1.5",
         "drupal/bootstrap": "^3.26",

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -34,7 +34,7 @@
         "composer/installers": "^1.2",
         "composer/semver": "^1.4",
         "cweagans/composer-patches": "dev-master#a18d1ca",
-        "devshop/devmaster": "^1.7@dev|1.x-dev",
+        "devshop/devmaster": "1.x-dev||^1.7@alpha",
         "drupal-composer/preserve-paths": "dev-composer2",
         "drupal/admin_menu": "@rc",
         "drupal/adminrole": "^1.1",

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -34,7 +34,7 @@
         "composer/installers": "^1.2",
         "composer/semver": "^1.4",
         "cweagans/composer-patches": "dev-master#a18d1ca",
-        "devshop/devmaster": "@dev",
+        "devshop/devmaster": "^1.7@dev",
         "drupal-composer/preserve-paths": "dev-composer2",
         "drupal/admin_menu": "@rc",
         "drupal/adminrole": "^1.1",

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -150,5 +150,6 @@
             "web/profiles"
         ]
     },
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -34,7 +34,7 @@
         "composer/installers": "^1.2",
         "composer/semver": "^1.4",
         "cweagans/composer-patches": "dev-master#a18d1ca",
-        "devshop/devmaster": "^1.7@alpha||1.x-dev",
+        "devshop/devmaster": "^1.7||1.x-dev",
         "drupal-composer/preserve-paths": "dev-composer2",
         "drupal/admin_menu": "@rc",
         "drupal/adminrole": "^1.1",
@@ -150,6 +150,6 @@
             "web/profiles"
         ]
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "alpha",
     "prefer-stable": true
 }

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -34,7 +34,7 @@
         "composer/installers": "^1.2",
         "composer/semver": "^1.4",
         "cweagans/composer-patches": "dev-master#a18d1ca",
-        "devshop/devmaster": "1.x-dev||^1.7@alpha",
+        "devshop/devmaster": "@dev||^1.7@alpha",
         "drupal-composer/preserve-paths": "dev-composer2",
         "drupal/admin_menu": "@rc",
         "drupal/adminrole": "^1.1",

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -34,7 +34,7 @@
         "composer/installers": "^1.2",
         "composer/semver": "^1.4",
         "cweagans/composer-patches": "dev-master#a18d1ca",
-        "devshop/devmaster": "@dev||^1.7@alpha",
+        "devshop/devmaster": "^1.7@alpha||1.x-dev",
         "drupal-composer/preserve-paths": "dev-composer2",
         "drupal/admin_menu": "@rc",
         "drupal/adminrole": "^1.1",

--- a/src/DevShop/Component/DevShopControlTemplate/composer.json
+++ b/src/DevShop/Component/DevShopControlTemplate/composer.json
@@ -34,7 +34,7 @@
         "composer/installers": "^1.2",
         "composer/semver": "^1.4",
         "cweagans/composer-patches": "dev-master#a18d1ca",
-        "devshop/devmaster": "^1.7@dev",
+        "devshop/devmaster": "^1.7@dev|1.x-dev",
         "drupal-composer/preserve-paths": "dev-composer2",
         "drupal/admin_menu": "@rc",
         "drupal/adminrole": "^1.1",


### PR DESCRIPTION
- [x] Ensure devmaster is at least 1.7
- [x] Add `workflow_dispatch` to "on" to allow manual workflow runs.
- [x] Run component tests twice a day just like the main tests.
- [x] Ensure `devshop/devmaster` is installed via symlink in main tests.
- [x] Ensure `devshop/devmaster` installs the latest release in component tests. 