### PR TITLE
Change "Lock Database" feature to "Protect Site"

### DIFF
--- a/devmaster/modules/devshop/devshop_projects/devshop_projects.drush.inc
+++ b/devmaster/modules/devshop/devshop_projects/devshop_projects.drush.inc
@@ -95,9 +95,6 @@ function drush_devshop_projects_pre_hosting_task()
     $task->options['tests-to-run'] = $task->task_args['tests_to_run'];
     $task->options['test-type'] = $task->task_args['test_type'];
   }
-
-  // On every task triggered by devshop, set this option.
-  $task->options['is-devshop'] = TRUE;
 }
 
 /**

--- a/devmaster/modules/devshop/devshop_projects/inc/forms.inc
+++ b/devmaster/modules/devshop/devshop_projects/inc/forms.inc
@@ -878,9 +878,9 @@ function devshop_projects_form_site_node_form_alter(&$form, &$form_state, $form_
   );
   $form['environment']['settings']['locked'] = array(
       '#type' => 'checkbox',
-      '#title' => t('Lock Database'),
+      '#title' => t('Protect Site'),
       '#default_value' => isset($environment->settings->locked) ? $environment->settings->locked : FALSE,
-      '#description' => t('Prevent devshop users from destroying the database.') . '<p class="text-danger">Drush users may still overwrite the database.</p>',
+      '#description' => t('Prevent devshop users from destroying the site.') . '<p class="text-danger">'. t('Users with server access can still destroy sites and data.') . '</p>',
   );
 
   $form['environment']['settings']['pull_disabled'] = array(

--- a/devmaster/modules/devshop/devshop_projects/inc/nodes.inc
+++ b/devmaster/modules/devshop/devshop_projects/inc/nodes.inc
@@ -129,6 +129,9 @@ function devshop_projects_node_load($nodes, $types) {
       if (empty($node->profile) && !empty($node->environment->settings->install_method['profile'])) {
         $node->profile_name = $node->environment->settings->install_method['profile'];
       }
+
+      // @TODO: Move "protected" property to hosting_site.
+      $node->protected = (bool) $node->environment->settings->locked?: false;
     }
   }
 }

--- a/devmaster/modules/devshop/devshop_projects/inc/theme.inc
+++ b/devmaster/modules/devshop/devshop_projects/inc/theme.inc
@@ -169,32 +169,7 @@ function devshop_projects_preprocess_node(&$vars) {
 
       // If "install" task, change name and add "force" task arg.
       $form = drupal_get_form('hosting_task_retry_form', $vars['node']->nid);
-
-      if ($vars['node']->task_type == 'install' && !$vars['node']->environment->settings->locked) {
-        $vars['retry'] = $form;
-        $vars['retry']['retry']['#value'] = t('Reinstall');
-      }
-      elseif ($vars['node']->task_type == 'install' && $vars['node']->environment->settings->locked) {
-        $vars['retry'] = array(
-          '#children' => t('Site is protected.'),
-          '#type' => 'container',
-          '#attributes' => array(
-            'class' => array('well well-sm')
-          ),
-        );
-        $settings_link = "node/{$vars['node']->rid}/edit";
-        if (drupal_valid_path($settings_link)) {
-          $vars['retry']['#children'] .= ' ' . l(t('Environment Settings'), $settings_link);
-        }
-      }
-      elseif ($vars['node']->task_type != 'install' && $vars['node']->task_type != 'delete') {
-        $vars['retry'] = $form;
-      }
-
-      // Change the name of the form button to "Run Again" if the task ended ok.
-      if ($vars['node']->task_status == HOSTING_TASK_WARNING || $vars['node']->task_status == HOSTING_TASK_SUCCESS) {
-        $vars['retry']['retry']['#value'] = t('Run Again');
-      }
+      $vars['retry'] = $form;
     }
 
     // Show duration

--- a/devmaster/themes/boots/environment.tpl.php
+++ b/devmaster/themes/boots/environment.tpl.php
@@ -236,8 +236,8 @@
         <?php endif; ?>
 
         <?php if (isset($environment->settings->locked) && $environment->settings->locked): ?>
-            <a class="environment-meta-data btn btn-text" title="<?php print t('This database is locked.'); ?>">
-          <i class="fa fa-lock"></i><?php print t('Locked') ?>
+            <a class="environment-meta-data btn btn-text" title="<?php print t('This site is protected.'); ?>">
+          <i class="fa fa-lock"></i><?php print t('Protected') ?>
         </a>
         <?php endif; ?>
 


### PR DESCRIPTION
- [ ] Remove custom logic for access control from theme layer.
- [ ] Create a pseudo "protected" node property so we can start developing off that.
- [ ] Replace $env->settings->locked with $env->protected.
- [ ] Hosting.module: 
  - [ ] Remove "Stop using disable before delete" feature and replace with "Protect Sites by default."
  - [ ] Replace hosting.module's "dangerous_tasks"  access control to use "protected" setting for tasks.
  - [ ] Add a "protected" column to hosting_site_schema.
  - [ ] Implement better protection for sites (prevent tasks, prevent node deletes, back up data, prevent data loss, etc. 