### PR TITLE
Fix failing 1.x tests where branch is needed.

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -260,6 +260,7 @@ jobs:
           - '7.4'
     env:
       working-directory: ./src/DevShop/Component/ControlProject
+      devmaster-directory: ./devmaster
     steps:
       - uses: actions/checkout@v1
 
@@ -299,7 +300,7 @@ jobs:
       - name: Install dependencies
         # Match the command in ./roles/opendevshop.devshop/tasks/main.yml
         run: |
-          composer config repositories.devmaster path ${GITHUB_WORKSPACE}
+          composer config repositories.devmaster path ${{env.devmaster-directory}}
           composer require devshop/devmaster:dev-${GIT_REF}
           composer install --no-dev --no-progress --prefer-source
         working-directory: ${{env.working-directory}}

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -300,7 +300,7 @@ jobs:
       - name: Install dependencies
         # Match the command in ./roles/opendevshop.devshop/tasks/main.yml
         run: |
-          composer config repositories.devmaster path ${{env.devmaster-directory}}
+          composer config repositories.devmaster path ${GITHUB_WORKSPACE}/devmaster
           composer require devshop/devmaster:dev-${GIT_REF}
           composer install --no-dev --no-progress --prefer-source
         working-directory: ${{env.working-directory}}

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -260,7 +260,7 @@ jobs:
           - '7.4'
     env:
       working-directory: ./src/DevShop/Component/ControlProject
-      devmaster-directory: ./devmaster
+      devmaster-directory: ../../../devmaster
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -15,6 +15,7 @@ env:
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha  }}
   GITHUB_RUN_LOG_URL: https://github.com/opendevshop/devshop/actions/runs/${{ github.run_id }}
+  GIT_REF: 1.x
 
 jobs:
   yaml-tasks:
@@ -262,6 +263,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Prepare Pull Request-only environment
+        if: github.event_name=='pull_request'
+        run: |
+          echo "GIT_REF=${{ github.head_ref }}" >> $GITHUB_ENV
+          git switch --create ${{ github.head_ref }}
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -292,7 +299,7 @@ jobs:
       - name: Install dependencies
         # Match the command in ./roles/opendevshop.devshop/tasks/main.yml
         run: |
-          composer require devshop/devmaster:dev-${{ github.event.pull_request.head.ref }}
+          composer require devshop/devmaster:dev-${GIT_REF}
           composer install --no-dev --no-progress --prefer-source
         working-directory: ${{env.working-directory}}
 

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -299,6 +299,7 @@ jobs:
       - name: Install dependencies
         # Match the command in ./roles/opendevshop.devshop/tasks/main.yml
         run: |
+          composer config repositories.devmaster path ${GITHUB_WORKSPACE}
           composer require devshop/devmaster:dev-${GIT_REF}
           composer install --no-dev --no-progress --prefer-source
         working-directory: ${{env.working-directory}}


### PR DESCRIPTION
Set GIT_REF environment variable to handle main branch and pull **request** branches.

See error: https://github.com/opendevshop/devshop/runs/1671224521#step:8:1

> Error: Could not find package devshop/devmaster in a version matching dev-
