### PR TITLE
Fix forked repo install tests.

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -189,6 +189,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.INPUT_GITHUB_TOKEN }}
         run: |
           ./github whoami
+        if: github.event.pull_request.head.repo.fork==false
+
+      - name: Test GitHub Cli on Forks
+        working-directory: ${{env.working-directory}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./github whoami
+        if: github.event.pull_request.head.repo.fork
 
   ComposerCommon:
     name: ComposerCommon

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -191,13 +191,16 @@ jobs:
           ./github whoami
         if: github.event.pull_request.head.repo.fork==false
 
-      - name: Test GitHub Cli on Forks
-        working-directory: ${{env.working-directory}}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ./github whoami
-        if: github.event.pull_request.head.repo.fork
+# @TODO: This is not currently possible because the GITHUB_TOKEN provided by github actions runs from forked repos does not have access to the user API. The error:
+#    Error: ]  Resource not accessible by integration
+#
+#      - name: Test GitHub Cli on Forks
+#        working-directory: ${{env.working-directory}}
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          ./github whoami
+#        if: github.event.pull_request.head.repo.fork
 
   ComposerCommon:
     name: ComposerCommon

--- a/.github/workflows/install-sh-test.sh
+++ b/.github/workflows/install-sh-test.sh
@@ -18,7 +18,8 @@ set -ex
 docker-compose --file docker/docker-compose.yml build base
 
 cd install
-cat build/install.sh | grep $LOAD_DEVSHOP_REF | grep $LOAD_DEVSHOP_REMOTE
+cat build/install.sh | grep $LOAD_DEVSHOP_REF
+cat build/install.sh | grep $LOAD_DEVSHOP_REMOTE
 
 # Launch a devshop/base container with this PR's install.sh script inside.
 docker run \

--- a/.github/workflows/install-sh-test.sh
+++ b/.github/workflows/install-sh-test.sh
@@ -1,13 +1,12 @@
 # Build a core container and run the install script in it.
 # Run from repository root:
 # bash .github/scripts/install-container.sh
-LOAD_DEVSHOP_VERSION=${LOAD_DEVSHOP_VERSION:-1.x}
+LOAD_DEVSHOP_REF=${GH_REF:-1.x}
+LOAD_DEVSHOP_REMOTE=${GH_REMOTE:-1.x}
 DEVSHOP_SERVER_HOSTNAME="install-test.devshop.local.computer"
 
-echo "Running test of install.sh script version $LOAD_DEVSHOP_VERSION..."
-echo "  To test a different version, specify the LOAD_DEVSHOP_VERSION environment variable: "
-echo ""
-echo "  LOAD_DEVSHOP_VERSION=example/branch bash .github/workflows/install-sh-test.sh"
+echo "Running test of install.sh script version $LOAD_DEVSHOP_REF from $LOAD_DEVSHOP_REMOTE ..."
+echo "  To test a different version, specify the LOAD_DEVSHOP_REF and/or LOAD_DEVSHOP_REMOTE environment variable: "
 
 # Remove existing install server test containers.
 docker kill install-server-test > /dev/null 2>&1
@@ -19,7 +18,7 @@ set -ex
 docker-compose --file docker/docker-compose.yml build base
 
 cd install
-cat build/install.sh | grep $LOAD_DEVSHOP_VERSION
+cat build/install.sh | grep $LOAD_DEVSHOP_REF | grep $LOAD_DEVSHOP_REMOTE
 
 # Launch a devshop/base container with this PR's install.sh script inside.
 docker run \

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -9,7 +9,9 @@ on:
     - cron: "0 12 * * *"
 
 env:
-  BRANCH: 1.x
+  GH_REF: 1.x
+  GH_REMOTE: "https://github.com/opendevshop/devshop.git"
+  GH_SHA: ""
 
 jobs:
   install_script:
@@ -20,9 +22,9 @@ jobs:
     - name: Prepare Pull Request-only environment
       if: github.event_name=='pull_request'
       run: |
-        echo "LOAD_DEVSHOP_VERSION=${{ github.head_ref }}" >> $GITHUB_ENV
-        echo "BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
-        echo "LOAD_DEVSHOP_SOURCE=${{ github.event.pull_request.head.repo.clone_url }}" >> $GITHUB_ENV
+        echo "GH_REF=${{ github.head_ref }}" >> $GITHUB_ENV
+        echo "GH_REMOTE=${{ github.event.pull_request.head.repo.clone_url }}" >> $GITHUB_ENV
+        echo "GH_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Check Out Sourcecode
       uses: actions/checkout@v2

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -9,8 +9,9 @@ on:
     - cron: "0 12 * * *"
 
 env:
-  GH_REF: 1.x
-  GH_REMOTE: "https://github.com/opendevshop/devshop.git"
+  # These must match netlify's environment, to ensure proper testing.
+  BRANCH: 1.x
+  REPOSITORY_URL: "https://github.com/opendevshop/devshop.git"
   GH_SHA: ""
 
 jobs:
@@ -21,10 +22,11 @@ jobs:
     steps:
     - name: Prepare Pull Request-only environment
       if: github.event_name=='pull_request'
+      # These must match netlify's environment, to ensure proper testing.
       run: |
-        echo "GH_REF=${{ github.head_ref }}" >> $GITHUB_ENV
-        echo "GH_REMOTE=${{ github.event.pull_request.head.repo.clone_url }}" >> $GITHUB_ENV
-        echo "GH_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        echo "BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+        echo "REPOSITORY_URL=${{ github.event.pull_request.head.repo.clone_url }}" >> $GITHUB_ENV
+        echo "COMMIT_REF=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Check Out Sourcecode
       uses: actions/checkout@v2

--- a/install/Makefile
+++ b/install/Makefile
@@ -6,7 +6,7 @@ build: build/install.sh
 
 build/install.sh: install.sh
 	mkdir -p $(@D)
-	LOAD_DEVSHOP_SHA='$(value GH_SHA)' LOAD_DEVSHOP_REF='$(value GH_REF)' LOAD_DEVSHOP_REMOTE='$(value GH_REMOTE)' envsubst '$(addprefix $$,$(ENVSUBST_VARS))' < $< > $@
+	LOAD_DEVSHOP_SHA='$(value COMMIT_REF)' LOAD_DEVSHOP_REF='$(value BRANCH)' LOAD_DEVSHOP_REMOTE='$(value REPOSITORY_URL)' envsubst '$(addprefix $$,$(ENVSUBST_VARS))' < $< > $@
 
 
 .PHONY: clean

--- a/install/Makefile
+++ b/install/Makefile
@@ -1,12 +1,12 @@
 
-ENVSUBST_VARS=LOAD_SCRIPT_DEVSHOP_VERSION_SHA LOAD_SCRIPT_DEVSHOP_VERSION_REF
+ENVSUBST_VARS=LOAD_DEVSHOP_SHA LOAD_DEVSHOP_REF LOAD_DEVSHOP_REMOTE
 
 .PHONY: build
 build: build/install.sh
 
 build/install.sh: install.sh
 	mkdir -p $(@D)
-	LOAD_SCRIPT_DEVSHOP_VERSION_SHA='$(shell git rev-parse HEAD)' LOAD_SCRIPT_DEVSHOP_VERSION_REF='$(value BRANCH)' envsubst '$(addprefix $$,$(ENVSUBST_VARS))' < $< > $@
+	LOAD_DEVSHOP_SHA='$(value GH_SHA)' LOAD_DEVSHOP_REF='$(value GH_REF)' LOAD_DEVSHOP_REMOTE='$(value GH_REMOTE)' envsubst '$(addprefix $$,$(ENVSUBST_VARS))' < $< > $@
 
 
 .PHONY: clean

--- a/install/install.sh
+++ b/install/install.sh
@@ -12,9 +12,9 @@ set -e
 #
 #   $ sh get-devshop.sh --hostname=devshop.example.com
 #
-# To use an alternate git repository or version, set the LOAD_DEVSHOP_VERSION or LOAD_DEVSHOP_SOURCE environment variables:
+# To use an alternate git repository or version, set the LOAD_DEVSHOP_REF or LOAD_DEVSHOP_REMOTE environment variables:
 #
-#   $ LOAD_SCRIPT_DEVSHOP_VERSION_REF=patch-123 LOAD_DEVSHOP_SOURCE=https://github.com/jonpugh/devshop.git bash install.sh
+#   $ LOAD_DEVSHOP_REF=patch-123 LOAD_DEVSHOP_REMOTE=https://github.com/jonpugh/devshop.git bash install.sh
 #
 # NOTE: Make sure to verify the contents of the script
 #       you downloaded matches the contents of install.sh
@@ -27,24 +27,25 @@ set -e
 # Git commit from https://github.com/opendevshop/devshop/blob/1.x/install/install.sh when
 # the script was uploaded (Should only be modified by upload job):
 # Will be the SHA used to publish the install.sh file to get.devshop.tech.
-SCRIPT_DEVSHOP_VERSION_SHA="${LOAD_SCRIPT_DEVSHOP_VERSION_SHA}"
-SCRIPT_DEVSHOP_VERSION_REF="${LOAD_SCRIPT_DEVSHOP_VERSION_REF}"
+SCRIPT_DEVSHOP_VERSION_REF="${LOAD_DEVSHOP_REF}"
+SCRIPT_DEVSHOP_VERSION_REMOTE="${LOAD_DEVSHOP_REMOTE}"
+SCRIPT_DEVSHOP_VERSION_SHA="${LOAD_DEVSHOP_SHA}"
 
 # Version to install (branch or tag).
-# If testing a branch is needed, set the DEVSHOP_VERSION environment variable in
+# If testing a branch is needed, set the DEVSHOP_REF environment variable in
 # the command line environment:
 #
-#     $ export DEVSHOP_VERSION=bug/XXX/fix
+#     $ export DEVSHOP_REF=bug/XXX/fix
 #     $ bash install.sh
 #
 # See the GitHub action ./.github/workflows/install.yml
 #
 
 # The version and git repo to install.
-# Default to 1.x if $SCRIPT_DEVSHOP_VERSION is empty.
+# Default to 1.x if $SCRIPT_DEVSHOP_VERSION_REF is empty.
 # Used as the `devshop_version` ansible variable, which will change the checked out version.
 DEVSHOP_VERSION="${SCRIPT_DEVSHOP_VERSION_REF:-1.x}"
-DEVSHOP_SOURCE="${LOAD_DEVSHOP_SOURCE:-http://github.com/opendevshop/devshop.git}"
+DEVSHOP_SOURCE="${SCRIPT_DEVSHOP_VERSION_REMOTE:-http://github.com/opendevshop/devshop.git}"
 
 # Version of Ansible to install
 ANSIBLE_VERSION=${ANSIBLE_VERSION:-"2.9"}


### PR DESCRIPTION
- Create new ENV vars for testing install script writing
- GH_X vars for vars coming from github actions.
- LOAD_DEVSHOP_REF and LOAD_DEVSHOP_REMOTE replacing DEVSHOP_VERSION, to allow installing a branch from any remote.
- Render a install.sh script for PRs using the forked URL.