### PR TITLE
Aegir User ID change playbook: stop supervisor properly.

### DIFF
--- a/roles/opendevshop.users/tasks/reset-uid.yml
+++ b/roles/opendevshop.users/tasks/reset-uid.yml
@@ -2,8 +2,8 @@
 
 # Supervisor isn't always installed at this point in the play, so allow errors.
 - name: "User ID Change: Stop supervisord"
-  service:
-    name: supervisord
+  supervisorctl:
+    name: hosting-queue-runner
     state: stopped
   ignore_errors: true
 


### PR DESCRIPTION
 Use supervisorctl ansible module to stop it instead of service to stop supervisor.