### PR TITLE
Update components tests to require right version.

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -315,7 +315,7 @@ jobs:
         # Match the command in ./roles/opendevshop.devshop/tasks/main.yml
         run: |
           composer config repositories.devmaster path ${GITHUB_WORKSPACE}/devmaster
-          composer require devshop/devmaster:dev-${GIT_REF}
+          composer require devshop/devmaster:${GIT_REF}-dev
           composer install --no-dev --no-progress --prefer-source
         working-directory: ${{env.working-directory}}
 


### PR DESCRIPTION
In the tests for DevShop Control, change the composer package version pattern to BRANCH-dev version constraint. It's failing when GIT_REF is 1.x: https://github.com/opendevshop/devshop/runs/2783160579#step:10:15