### PR TITLE
Fix 'docker-compose up' after git clone.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,9 @@ services:
       - ANSIBLE_CONFIG
       - FROM_IMAGE
       - OS_VERSION
-      - DEVSHOP_DOCKER_COMMAND_RUN
+
+      # Default to the same value so it does not get overridden if it is not in docker-compose exec environment.
+      - DEVSHOP_DOCKER_COMMAND_RUN=${DEVSHOP_DOCKER_COMMAND_RUN:-/usr/share/devshop/scripts/devshop-ansible-playbook   --tags runtime}
       - DOCKER_COMMAND_POST=${DOCKER_COMMAND_POST:-devshop login}
       - DOCKER_COMMAND_POST
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,12 @@ services:
       - /var/lib/mysql
       - /var/logs/aegir
 
+      - ./:/usr/share/devshop:delegated
+      - ./aegir-home:/var/aegir:delegated
+      - ./roles/devshop.server/inventory:/etc/ansible/hosts
+
+      - $HOME/.ssh:/var/aegir/.ssh
+
     # Resource allocation.
     # 4GB, 2CPUs is a good minimum.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,6 @@ services:
       - ./aegir-home:/var/aegir:delegated
       - ./roles/devshop.server/inventory:/etc/ansible/hosts
 
-      - $HOME/.ssh:/var/aegir/.ssh
-
     # Resource allocation.
     # 4GB, 2CPUs is a good minimum.
 

--- a/roles/devshop.server/play.yml
+++ b/roles/devshop.server/play.yml
@@ -37,33 +37,6 @@
       when:
         - ('runtime' not in ansible_run_tags)
 
-    # Copied from geerlingguy.mysql variables.yml so it will run at runtime.
-    - name: Include OS-specific variables.
-      include_vars: "{{ item }}"
-      with_first_found:
-        - files:
-            - "{{ devshop_cli_path }}/roles/geerlingguy.mysql/vars/{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-            - "{{ devshop_cli_path }}/roles/geerlingguy.mysql/vars/{{ ansible_os_family }}.yml"
-      tags: [always]
-
-    - name: Define mysql_daemon.
-      set_fact:
-        mysql_daemon: "{{ __mysql_daemon }}"
-      when: mysql_daemon is not defined
-      tags: [always]
-
-    - name: MySQL Information
-      debug:
-        msg: "MySQL Root password: {{ mysql_root_password }}"
-      tags: [always]
-
-    # This is here for the devshop/server container, which already has mysql installed. For some reason, it wouldn't start later on.
-    # @TODO: This works, but using Service module fails!
-    - name: Start MySQL
-      command: "service {{ mysql_daemon }} start"
-      ignore_errors: true
-      tags: [runtime]
-
   roles:
     # Run the opendevshop.users role first at runtime so UIDs are changed ASAP.
     # The playbook will ALSO be run before opendevshop.devmaster below because it is stored as a dependency.


### PR DESCRIPTION
A `docker-compose up` run after git clone resulted in an empty container. 

The DEVSHOP_DOCKER_COMMAND_RUN was being set to an empty string by it being in the `docker-compose.yml` file.

Fixed by adding a copy of the default run command to docker-compose.yml