### PR TITLE
Add Site Audit 7.x

### DIFF
--- a/devmaster/devmaster.info
+++ b/devmaster/devmaster.info
@@ -57,6 +57,7 @@ dependencies[] = actions_permissions
 dependencies[] = r4032login
 dependencies[] = jquery_update
 dependencies[] = module_filter
+dependencies[] = site_audit
 
 ; This breaks hosting.install.  Removing it for now.
 ;dependencies[] = adminrole

--- a/src/DevShop/Control/composer.json
+++ b/src/DevShop/Control/composer.json
@@ -81,6 +81,7 @@
         "drupal/overlay_paths": "^1.3",
         "drupal/provision": "dev-4.x",
         "drupal/r4032login": "^1.8",
+        "drupal/site_audit": "^2.0",
         "drupal/sshkey": "^2.0",
         "drupal/statsd": "^1.1",
         "drupal/timeago": "^2.3",

--- a/src/DevShop/Control/composer.lock
+++ b/src/DevShop/Control/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f607097426ead0384b8afb3ca617f1b",
+    "content-hash": "125a11ff355b8dd1099ce3b213c472c2",
     "packages": [
         {
             "name": "behat/behat",
@@ -3700,6 +3700,63 @@
             "homepage": "https://www.drupal.org/project/r4032login",
             "support": {
                 "source": "https://git.drupalcode.org/project/r4032login"
+            }
+        },
+        {
+            "name": "drupal/site_audit",
+            "version": "2.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/site_audit.git",
+                "reference": "7.x-2.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/site_audit-7.x-2.0-beta1.zip",
+                "reference": "7.x-2.0-beta1",
+                "shasum": "bc33b6579cc74c879aad8347a9fdf9dab5ecbeea"
+            },
+            "require": {
+                "drupal/drupal": "~7.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "7.x-2.0-beta1",
+                    "datestamp": "1689637032",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/7/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Site Audit Maintainers",
+                    "homepage": "https://git.drupalcode.org/project/site_audit/-/graphs/4.0.x"
+                },
+                {
+                    "name": "Jon Pugh",
+                    "homepage": "https://www.drupal.org/user/17028"
+                },
+                {
+                    "name": "jrglasgow",
+                    "homepage": "https://www.drupal.org/user/36590"
+                },
+                {
+                    "name": "leymannx",
+                    "homepage": "https://www.drupal.org/user/2482808"
+                }
+            ],
+            "description": "This extension provides Site Audit commands for The Drupal UI and Drush.",
+            "homepage": "https://www.drupal.org/project/site_audit",
+            "support": {
+                "source": "https://git.drupalcode.org/project/site_audit",
+                "issues": "https://www.drupal.org/project/issues/site_audit"
             }
         },
         {


### PR DESCRIPTION
Site Audit 7.x-2.0 has a web UI. It's pretty useful for devshop control, so let's add it.