### PR TITLE
Composer install destroys.

### DIFF
--- a/src/DevShop/Control/composer.json
+++ b/src/DevShop/Control/composer.json
@@ -186,7 +186,7 @@
             "web/sites/all/themes/contrib/{$name}/": ["type:drupal-theme"]
       },
       "preserve-paths": [
-          "web/sites/default",
+          "web/sites",
           "web/profiles/devmaster"
         ]
     },


### PR DESCRIPTION
 Sometimes, composer install destroys the sites/X.com folder in devmaster.

I think if we set web/sites, it will preserve all paths under web/sites.